### PR TITLE
ci(web): add frontend validation pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,40 @@ jobs:
           OPENAI_MODEL: gpt-4.1-mini
         run: pnpm --dir apps/backend test
 
+  frontend-validation:
+    name: Frontend Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Frontend lint
+        run: pnpm exec eslint "apps/web/src/**/*.{ts,html}"
+
+      - name: Frontend app typecheck
+        run: pnpm --dir apps/web exec tsc --project tsconfig.app.json --noEmit
+
+      - name: Frontend spec typecheck
+        run: pnpm --dir apps/web exec tsc --project tsconfig.spec.json --noEmit
+
+      - name: Frontend headless tests
+        run: pnpm --dir apps/web test -- --watch=false
+
   backend-db-integration:
     name: Backend DB Integration
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: pnpm --dir apps/web exec tsc --project tsconfig.spec.json --noEmit
 
       - name: Frontend headless tests
-        run: pnpm --dir apps/web test -- --watch=false
+        run: pnpm --dir apps/web test --watch=false
 
   backend-db-integration:
     name: Backend DB Integration


### PR DESCRIPTION
## Linked Issue
Closes #9

## Type
- [x] Maintenance/tooling
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Breaking change

## Summary
- add a dedicated `Frontend Validation` job to the main CI workflow for `apps/web`
- validate frontend lint, app/spec typecheck, and headless tests without adding production build to this first slice
- provide a real GitHub Actions check that can be used as evidence for the workflow-only SDD change

## Changes Table
| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added `Frontend Validation` job with pnpm setup, frontend lint, app/spec typecheck, and headless tests |

## Test Plan
- [x] `pnpm exec prettier --check .github/workflows/ci.yml`
- [x] `git diff --check`
- [x] `pnpm exec eslint apps/web/src/**/*.{ts,html}`
- [x] `pnpm --dir apps/web exec tsc --project tsconfig.app.json --noEmit`
- [x] `pnpm --dir apps/web exec tsc --project tsconfig.spec.json --noEmit`
- [x] `pnpm --dir apps/web test -- --watch=false`
- [x] No shell scripts changed, so shellcheck is not applicable

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts or confirmed no scripts changed
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers