### PR TITLE
feat(runtime): enforce project rate limiting

### DIFF
--- a/apps/backend/src/__tests__/app.integration.test.ts
+++ b/apps/backend/src/__tests__/app.integration.test.ts
@@ -1,6 +1,7 @@
 import request from 'supertest';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Express } from 'express';
+import { resetRateLimitStoreForTests } from '../mock-server/rate-limit.js';
 
 const openaiCreateMock = vi.fn();
 
@@ -64,6 +65,55 @@ vi.mock('openai', () => ({
 
 let app: Express;
 
+function buildMockProject(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'p1',
+    slug: 'demo',
+    globalConfig: {
+      latencyEnabled: false,
+      latencyMode: 'fixed',
+      latencyMinMs: 0,
+      latencyMaxMs: 0,
+      scope: 'all',
+      errorSimulationEnabled: false,
+      errorSimulationRate: 0,
+      errorSimulationCodes: [500],
+      rateLimitingEnabled: false,
+      rateLimitingRpm: 60,
+      loggingLevel: 'basic',
+    },
+    ...overrides,
+  };
+}
+
+function buildRateLimitedProject(overrides: Record<string, unknown> = {}) {
+  return buildMockProject({
+    globalConfig: {
+      ...buildMockProject().globalConfig,
+      rateLimitingEnabled: true,
+      rateLimitingRpm: 2,
+      ...overrides,
+    },
+  });
+}
+
+function buildMockEndpoint(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'e1',
+    endpointConfig: {
+      latencyMode: 'fixed',
+      fixedDelayMs: 0,
+      minDelayMs: 0,
+      maxDelayMs: 0,
+      useScenarioWeights: true,
+    },
+    scenarios: [],
+    statusCode: 200,
+    responseBody: { ok: true },
+    ...overrides,
+  };
+}
+
 describe('app integration', () => {
   beforeAll(async () => {
     process.env.DATABASE_URL ??= 'postgresql://user:password@localhost:5432/simulador_api_ia_test';
@@ -74,7 +124,9 @@ describe('app integration', () => {
   });
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
+    resetRateLimitStoreForTests();
   });
 
   it('GET /api/v1/projects responde lista', async () => {
@@ -202,33 +254,9 @@ describe('app integration', () => {
   });
 
   it('GET /mock/:projectSlug/:path responde y loguea fire-and-forget', async () => {
-    prismaMock.project.findUnique.mockResolvedValueOnce({
-      id: 'p1',
-      globalConfig: {
-        latencyEnabled: false,
-        latencyMode: 'fixed',
-        latencyMinMs: 0,
-        latencyMaxMs: 0,
-        scope: 'all',
-        errorSimulationEnabled: false,
-        errorSimulationRate: 0,
-        errorSimulationCodes: [500],
-      },
-    });
+    prismaMock.project.findUnique.mockResolvedValueOnce(buildMockProject());
 
-    prismaMock.endpoint.findFirst.mockResolvedValueOnce({
-      id: 'e1',
-      endpointConfig: {
-        latencyMode: 'fixed',
-        fixedDelayMs: 0,
-        minDelayMs: 0,
-        maxDelayMs: 0,
-        useScenarioWeights: true,
-      },
-      scenarios: [],
-      statusCode: 200,
-      responseBody: { ok: true },
-    });
+    prismaMock.endpoint.findFirst.mockResolvedValueOnce(buildMockEndpoint());
 
     prismaMock.apiLog.create.mockResolvedValueOnce({ id: 'l1' });
 
@@ -238,6 +266,136 @@ describe('app integration', () => {
     expect(response.body).toEqual({ ok: true });
     expect(response.headers['x-simulador-scenario']).toBe('direct');
     expect(prismaMock.apiLog.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('GET /mock/:projectSlug/:path aplica rate limiting habilitado y expone headers de cuota', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(65_000);
+    prismaMock.project.findUnique.mockResolvedValue(buildRateLimitedProject());
+    prismaMock.endpoint.findFirst.mockResolvedValue(buildMockEndpoint());
+    prismaMock.apiLog.create.mockResolvedValue({ id: 'l1' });
+
+    const first = await request(app).get('/mock/demo/users');
+    const second = await request(app).get('/mock/demo/users');
+
+    expect(first.status).toBe(200);
+    expect(first.headers['x-ratelimit-limit']).toBe('2');
+    expect(first.headers['x-ratelimit-remaining']).toBe('1');
+    expect(first.headers['x-ratelimit-reset']).toBe('120');
+    expect(first.headers['retry-after']).toBeUndefined();
+
+    expect(second.status).toBe(200);
+    expect(second.headers['x-ratelimit-limit']).toBe('2');
+    expect(second.headers['x-ratelimit-remaining']).toBe('0');
+    expect(second.headers['x-ratelimit-reset']).toBe('120');
+  });
+
+  it('GET /mock/:projectSlug/:path bloquea el request N+1 con 429, retry-after y logging', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(65_000);
+    prismaMock.project.findUnique.mockResolvedValue(buildRateLimitedProject());
+    prismaMock.endpoint.findFirst.mockResolvedValue(buildMockEndpoint());
+    prismaMock.apiLog.create.mockResolvedValue({ id: 'l1' });
+
+    await request(app).get('/mock/demo/users');
+    await request(app).get('/mock/demo/users');
+    const blocked = await request(app).get('/mock/demo/users');
+
+    expect(blocked.status).toBe(429);
+    expect(blocked.body).toEqual({ error: 'Rate limit exceeded' });
+    expect(blocked.headers['x-ratelimit-limit']).toBe('2');
+    expect(blocked.headers['x-ratelimit-remaining']).toBe('0');
+    expect(blocked.headers['x-ratelimit-reset']).toBe('120');
+    expect(blocked.headers['retry-after']).toBe('55');
+    expect(blocked.headers['x-simulador-scenario']).toBeUndefined();
+    expect(blocked.headers['x-simulador-latency']).toBeUndefined();
+
+    expect(prismaMock.apiLog.create).toHaveBeenLastCalledWith({
+      data: expect.objectContaining({
+        projectId: 'p1',
+        origin: 'mock',
+        statusCode: 429,
+        latencyMs: 0,
+        scenarioType: 'rate-limit-block',
+        scenarioSelectionSource: 'rate-limit',
+        scenarioName: null,
+        responseHeaders: {
+          'X-RateLimit-Limit': '2',
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': '120',
+          'Retry-After': '55',
+          'Content-Type': 'application/json',
+        },
+      }),
+    });
+  });
+
+  it('GET /mock/:projectSlug/:path resetea la cuota cuando entra una nueva ventana', async () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(65_000)
+      .mockReturnValueOnce(65_000)
+      .mockReturnValueOnce(121_000);
+    prismaMock.project.findUnique.mockResolvedValue(
+      buildRateLimitedProject({ rateLimitingRpm: 1 })
+    );
+    prismaMock.endpoint.findFirst.mockResolvedValue(buildMockEndpoint());
+    prismaMock.apiLog.create.mockResolvedValue({ id: 'l1' });
+
+    const first = await request(app).get('/mock/demo/users');
+    const blocked = await request(app).get('/mock/demo/users');
+    const reset = await request(app).get('/mock/demo/users');
+
+    expect(first.status).toBe(200);
+    expect(blocked.status).toBe(429);
+    expect(reset.status).toBe(200);
+    expect(reset.headers['x-ratelimit-limit']).toBe('1');
+    expect(reset.headers['x-ratelimit-remaining']).toBe('0');
+    expect(reset.headers['x-ratelimit-reset']).toBe('180');
+  });
+
+  it('GET /mock/:projectSlug/:path bypasses limiter and omits rate-limit headers when disabled', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(65_000);
+    prismaMock.project.findUnique.mockResolvedValue(
+      buildMockProject({
+        globalConfig: {
+          ...buildMockProject().globalConfig,
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 1,
+        },
+      })
+    );
+    prismaMock.endpoint.findFirst.mockResolvedValue(buildMockEndpoint());
+    prismaMock.apiLog.create.mockResolvedValue({ id: 'l1' });
+
+    const first = await request(app).get('/mock/demo/users');
+    const second = await request(app).get('/mock/demo/users');
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(first.headers['x-ratelimit-limit']).toBeUndefined();
+    expect(first.headers['x-ratelimit-remaining']).toBeUndefined();
+    expect(first.headers['x-ratelimit-reset']).toBeUndefined();
+    expect(second.headers['x-ratelimit-limit']).toBeUndefined();
+    expect(second.headers['retry-after']).toBeUndefined();
+  });
+
+  it('GET /mock/:projectSlug/:path ignores scope for MVP and keeps project-wide enforcement', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(65_000);
+    prismaMock.project.findUnique.mockResolvedValue(
+      buildRateLimitedProject({
+        rateLimitingRpm: 1,
+        scope: 'unset',
+      })
+    );
+    prismaMock.endpoint.findFirst.mockResolvedValue(buildMockEndpoint());
+    prismaMock.apiLog.create.mockResolvedValue({ id: 'l1' });
+
+    const first = await request(app).get('/mock/demo/users');
+    const blocked = await request(app).get('/mock/demo/users');
+
+    expect(first.status).toBe(200);
+    expect(first.headers['x-ratelimit-limit']).toBe('1');
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers['x-ratelimit-limit']).toBe('1');
+    expect(blocked.headers['retry-after']).toBe('55');
   });
 
   it('GET /api/v1/projects/:projectId/logs devuelve últimos logs', async () => {

--- a/apps/backend/src/mock-server/__tests__/rate-limit.test.ts
+++ b/apps/backend/src/mock-server/__tests__/rate-limit.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { createRuntimeRateLimiter, resetRateLimitStoreForTests } from '../rate-limit.js';
+
+describe('mock-server/rate-limit', () => {
+  it('allow/exhaust dentro de la misma ventana alineada con headers consistentes', () => {
+    const nowMs = 65_000;
+    const limiter = createRuntimeRateLimiter({ now: () => nowMs });
+
+    const first = limiter.evaluate('project-1', 2);
+    const second = limiter.evaluate('project-1', 2);
+    const third = limiter.evaluate('project-1', 2);
+
+    expect(first).toMatchObject({
+      allowed: true,
+      limit: 2,
+      remaining: 1,
+      resetAtMs: 120_000,
+      retryAfterSeconds: 55,
+      headers: {
+        'X-RateLimit-Limit': '2',
+        'X-RateLimit-Remaining': '1',
+        'X-RateLimit-Reset': '120',
+      },
+    });
+
+    expect(second).toMatchObject({
+      allowed: true,
+      limit: 2,
+      remaining: 0,
+      resetAtMs: 120_000,
+      retryAfterSeconds: 55,
+      headers: {
+        'X-RateLimit-Limit': '2',
+        'X-RateLimit-Remaining': '0',
+        'X-RateLimit-Reset': '120',
+      },
+    });
+
+    expect(third).toMatchObject({
+      allowed: false,
+      limit: 2,
+      remaining: 0,
+      resetAtMs: 120_000,
+      retryAfterSeconds: 55,
+      headers: {
+        'X-RateLimit-Limit': '2',
+        'X-RateLimit-Remaining': '0',
+        'X-RateLimit-Reset': '120',
+      },
+    });
+  });
+
+  it('resetea la cuota cuando cambia la ventana', () => {
+    let nowMs = 65_000;
+    const limiter = createRuntimeRateLimiter({ now: () => nowMs });
+
+    limiter.evaluate('project-1', 1);
+    const blocked = limiter.evaluate('project-1', 1);
+
+    nowMs = 121_000;
+
+    const reset = limiter.evaluate('project-1', 1);
+
+    expect(blocked).toMatchObject({
+      allowed: false,
+      remaining: 0,
+      resetAtMs: 120_000,
+      retryAfterSeconds: 55,
+    });
+
+    expect(reset).toMatchObject({
+      allowed: true,
+      limit: 1,
+      remaining: 0,
+      resetAtMs: 180_000,
+      retryAfterSeconds: 59,
+      headers: {
+        'X-RateLimit-Limit': '1',
+        'X-RateLimit-Remaining': '0',
+        'X-RateLimit-Reset': '180',
+      },
+    });
+  });
+
+  it('resetRateLimitStoreForTests limpia el store compartido', () => {
+    const nowMs = 10_000;
+    const firstLimiter = createRuntimeRateLimiter({ now: () => nowMs });
+
+    firstLimiter.evaluate('project-1', 1);
+    expect(firstLimiter.evaluate('project-1', 1).allowed).toBe(false);
+
+    resetRateLimitStoreForTests();
+
+    const secondLimiter = createRuntimeRateLimiter({ now: () => nowMs });
+    expect(secondLimiter.evaluate('project-1', 1)).toMatchObject({
+      allowed: true,
+      remaining: 0,
+      resetAtMs: 60_000,
+      retryAfterSeconds: 50,
+    });
+  });
+});

--- a/apps/backend/src/mock-server/logger.ts
+++ b/apps/backend/src/mock-server/logger.ts
@@ -1,16 +1,32 @@
 import { prisma } from '../lib/prisma.js';
 import { toNullablePrismaJson, toPrismaJson } from '../lib/prisma-json.js';
 
+export type MockLogOrigin = 'mock' | 'forced-error';
+export type MockLogScenarioType =
+  | 'success'
+  | 'error'
+  | 'timeout'
+  | 'empty'
+  | 'forced-error'
+  | 'default'
+  | 'rate-limit-block';
+export type MockLogScenarioSelectionSource =
+  | 'weighted-random'
+  | 'uniform-random'
+  | 'direct-endpoint'
+  | 'forced-error'
+  | 'rate-limit';
+
 export interface MockLogInput {
   projectId: string;
   method: string;
   path: string;
   fullUrl: string;
-  origin: 'mock' | 'forced-error';
+  origin: MockLogOrigin;
   statusCode: number;
   latencyMs: number;
-  scenarioType: string;
-  scenarioSelectionSource: string;
+  scenarioType: MockLogScenarioType;
+  scenarioSelectionSource: MockLogScenarioSelectionSource;
   scenarioName: string | null;
   requestHeaders: Record<string, string>;
   requestBody: unknown;

--- a/apps/backend/src/mock-server/mock.router.ts
+++ b/apps/backend/src/mock-server/mock.router.ts
@@ -1,10 +1,12 @@
 import { Router, type NextFunction, type Request, type Response } from 'express';
 import { prisma } from '../lib/prisma.js';
 import { applyLatency, calculateLatency } from './latency.js';
-import { logRequest, type LoggingLevel } from './logger.js';
+import { logRequest, type LoggingLevel, type MockLogInput } from './logger.js';
+import { createRuntimeRateLimiter } from './rate-limit.js';
 import { selectScenario } from './scenario-selector.js';
 
 export const mockRouter = Router();
+const runtimeRateLimiter = createRuntimeRateLimiter();
 
 function toStringHeaders(headers: Record<string, unknown>): Record<string, string> {
   const normalizedEntries = Object.entries(headers).map(([key, value]) => {
@@ -20,6 +22,12 @@ function toStringHeaders(headers: Record<string, unknown>): Record<string, strin
   });
 
   return Object.fromEntries(normalizedEntries);
+}
+
+function setHeaders(res: Response, headers: Record<string, string>): void {
+  for (const [key, value] of Object.entries(headers)) {
+    res.setHeader(key, value);
+  }
 }
 
 function parseErrorCodes(input: unknown): number[] {
@@ -52,6 +60,12 @@ function toAbsoluteUrl(req: Request): string {
   const host = req.get('host');
   const base = host ? `${req.protocol}://${host}` : 'http://localhost';
   return new URL(req.originalUrl, base).toString();
+}
+
+function toMockScenarioType(value: string | null | undefined): MockLogInput['scenarioType'] {
+  return value === 'success' || value === 'error' || value === 'timeout' || value === 'empty'
+    ? value
+    : 'default';
 }
 
 async function resolveMockRequest(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -120,6 +134,44 @@ async function resolveMockRequest(req: Request, res: Response, next: NextFunctio
       Math.random() < project.globalConfig.errorSimulationRate;
     const loggingLevel = resolveLoggingLevel(project.globalConfig?.loggingLevel);
     const fullUrl = toAbsoluteUrl(req);
+    const isRateLimitEnabled = project.globalConfig?.rateLimitingEnabled === true;
+    const rateLimitResult = isRateLimitEnabled
+      ? runtimeRateLimiter.evaluate(project.id, project.globalConfig?.rateLimitingRpm ?? 60)
+      : null;
+
+    if (rateLimitResult && !rateLimitResult.allowed) {
+      const responseBody = { error: 'Rate limit exceeded' };
+      const responseHeaders = {
+        ...rateLimitResult.headers,
+        'Retry-After': String(rateLimitResult.retryAfterSeconds),
+        'Content-Type': 'application/json',
+      };
+
+      setHeaders(res, responseHeaders);
+      res.status(429).json(responseBody);
+
+      logRequest(
+        {
+          projectId: project.id,
+          method,
+          path: requestedPath,
+          fullUrl,
+          origin: 'mock',
+          statusCode: 429,
+          latencyMs: 0,
+          scenarioType: 'rate-limit-block',
+          scenarioSelectionSource: 'rate-limit',
+          scenarioName: null,
+          requestHeaders: toStringHeaders(req.headers as Record<string, unknown>),
+          requestBody: req.body ?? null,
+          responseHeaders,
+          responseBody,
+        },
+        loggingLevel
+      ).catch(() => {});
+
+      return;
+    }
 
     if (shouldForceError) {
       const forcedLatencyMs = calculateLatency(0, endpointLatencyConfig, globalLatencyConfig);
@@ -127,6 +179,7 @@ async function resolveMockRequest(req: Request, res: Response, next: NextFunctio
       const forcedStatusCode = pickRandom(forcedCodes);
       const forcedBody = {};
       const responseHeaders = {
+        ...(rateLimitResult?.headers ?? {}),
         'X-Simulador-Scenario': 'forced-error',
         'X-Simulador-Latency': String(forcedLatencyMs),
         'Content-Type': 'application/json',
@@ -134,9 +187,7 @@ async function resolveMockRequest(req: Request, res: Response, next: NextFunctio
 
       await applyLatency(forcedLatencyMs);
 
-      res.setHeader('X-Simulador-Scenario', responseHeaders['X-Simulador-Scenario']);
-      res.setHeader('X-Simulador-Latency', responseHeaders['X-Simulador-Latency']);
-      res.setHeader('Content-Type', responseHeaders['Content-Type']);
+      setHeaders(res, responseHeaders);
       res.status(forcedStatusCode).json(forcedBody);
 
       logRequest(
@@ -219,17 +270,16 @@ async function resolveMockRequest(req: Request, res: Response, next: NextFunctio
     const responseBody = selectedScenario?.body ?? endpoint.responseBody;
     const scenarioName = selectedScenario?.name ?? null;
     const scenarioHeader = scenarioName ?? 'direct';
-    const scenarioType = selectedScenario?.type ?? 'default';
+    const scenarioType = toMockScenarioType(selectedScenario?.type);
 
     const responseHeaders = {
+      ...(rateLimitResult?.headers ?? {}),
       'X-Simulador-Scenario': scenarioHeader,
       'X-Simulador-Latency': String(latencyMs),
       'Content-Type': 'application/json',
     };
 
-    res.setHeader('X-Simulador-Scenario', responseHeaders['X-Simulador-Scenario']);
-    res.setHeader('X-Simulador-Latency', responseHeaders['X-Simulador-Latency']);
-    res.setHeader('Content-Type', responseHeaders['Content-Type']);
+    setHeaders(res, responseHeaders);
     res.status(statusCode).json(responseBody);
 
     logRequest(

--- a/apps/backend/src/mock-server/rate-limit.ts
+++ b/apps/backend/src/mock-server/rate-limit.ts
@@ -1,0 +1,86 @@
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+interface RateLimitBucket {
+  windowStartMs: number;
+  count: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAtMs: number;
+  retryAfterSeconds: number;
+  headers: Record<string, string>;
+}
+
+interface RuntimeRateLimiterOptions {
+  now?: () => number;
+}
+
+const rateLimitStore = new Map<string, RateLimitBucket>();
+
+function normalizeLimit(limit: number): number {
+  return Math.max(1, Math.floor(limit));
+}
+
+function getWindowStartMs(nowMs: number): number {
+  return Math.floor(nowMs / RATE_LIMIT_WINDOW_MS) * RATE_LIMIT_WINDOW_MS;
+}
+
+function getResetAtMs(windowStartMs: number): number {
+  return windowStartMs + RATE_LIMIT_WINDOW_MS;
+}
+
+function getRetryAfterSeconds(resetAtMs: number, nowMs: number): number {
+  return Math.max(1, Math.ceil((resetAtMs - nowMs) / 1000));
+}
+
+function buildRateLimitHeaders(
+  limit: number,
+  remaining: number,
+  resetAtMs: number
+): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(limit),
+    'X-RateLimit-Remaining': String(remaining),
+    'X-RateLimit-Reset': String(Math.floor(resetAtMs / 1000)),
+  };
+}
+
+export function createRuntimeRateLimiter(options: RuntimeRateLimiterOptions = {}) {
+  return {
+    evaluate(key: string, limit: number): RateLimitResult {
+      const normalizedLimit = normalizeLimit(limit);
+      const nowMs = (options.now ?? Date.now)();
+      const windowStartMs = getWindowStartMs(nowMs);
+      const resetAtMs = getResetAtMs(windowStartMs);
+      const current = rateLimitStore.get(key);
+      const bucket =
+        current && current.windowStartMs === windowStartMs
+          ? current
+          : ({ windowStartMs, count: 0 } satisfies RateLimitBucket);
+
+      const nextCount = bucket.count + 1;
+      const allowed = nextCount <= normalizedLimit;
+      const persistedCount = allowed ? nextCount : bucket.count;
+      const remaining = Math.max(0, normalizedLimit - persistedCount);
+      const nextBucket = { windowStartMs, count: persistedCount } satisfies RateLimitBucket;
+
+      rateLimitStore.set(key, nextBucket);
+
+      return {
+        allowed,
+        limit: normalizedLimit,
+        remaining,
+        resetAtMs,
+        retryAfterSeconds: getRetryAfterSeconds(resetAtMs, nowMs),
+        headers: buildRateLimitHeaders(normalizedLimit, remaining, resetAtMs),
+      };
+    },
+  };
+}
+
+export function resetRateLimitStoreForTests(): void {
+  rateLimitStore.clear();
+}

--- a/apps/web/src/app/features/global-config/components/global-config-drawer/global-config-drawer.component.html
+++ b/apps/web/src/app/features/global-config/components/global-config-drawer/global-config-drawer.component.html
@@ -211,7 +211,9 @@
                 [disabled]="!state().rateLimiting.enabled"
                 (input)="onRpmInput($any($event.target).value)"
               />
-              <p class="gcfg-helper">Limit how many requests can be handled per minute</p>
+              <p class="gcfg-helper">
+                Limit how many requests can be handled per minute across the whole mock runtime for this project.
+              </p>
             </div>
           </section>
 

--- a/apps/web/src/app/features/logs/adapters/logs-api.mapper.spec.ts
+++ b/apps/web/src/app/features/logs/adapters/logs-api.mapper.spec.ts
@@ -63,4 +63,29 @@ describe('logs-api.mapper', () => {
     expect(result.nextCursor).toEqual({ createdAt: '2026-04-04T10:11:12.000Z', id: 'l1' });
     expect(result.serverTime).toBe('2026-04-04T10:11:30.000Z');
   });
+
+  it('preserves rate-limit block metadata for runtime logs', () => {
+    const result = mapLogFromApi({
+      id: 'l-rl',
+      projectId: 'p1',
+      method: 'GET',
+      path: '/users',
+      fullUrl: 'https://mock.example.com/users',
+      origin: 'mock',
+      statusCode: 429,
+      latencyMs: 0,
+      scenarioType: 'rate-limit-block',
+      scenarioSelectionSource: 'rate-limit',
+      scenarioName: null,
+      hasScenario: false,
+      requestHeaders: {},
+      requestBody: null,
+      responseHeaders: { 'retry-after': '55' },
+      responseBody: { error: 'Rate limit exceeded' },
+      createdAt: '2026-04-08T12:00:00.000Z',
+    });
+
+    expect(result.scenario).toBe('rate-limit-block');
+    expect(result.scenarioSelectionSource).toBe('rate-limit');
+  });
 });

--- a/apps/web/src/app/features/logs/adapters/logs-api.mapper.ts
+++ b/apps/web/src/app/features/logs/adapters/logs-api.mapper.ts
@@ -10,13 +10,14 @@ function normalizeScenario(value: string): LogScenarioKind {
     value === 'error' ||
     value === 'timeout' ||
     value === 'empty' ||
-    value === 'forced-error'
+    value === 'forced-error' ||
+    value === 'rate-limit-block'
     ? value
     : 'default';
 }
 
 function normalizeSelectionSource(value: string): ScenarioSelectionSource {
-  return value === 'weighted-random' || value === 'uniform-random' || value === 'forced-error'
+  return value === 'weighted-random' || value === 'uniform-random' || value === 'forced-error' || value === 'rate-limit'
     ? value
     : 'direct-endpoint';
 }

--- a/apps/web/src/app/features/logs/components/logs-detail-sidebar/logs-detail-sidebar.component.spec.ts
+++ b/apps/web/src/app/features/logs/components/logs-detail-sidebar/logs-detail-sidebar.component.spec.ts
@@ -30,6 +30,26 @@ const noScenarioLogFixture: ApiLogEntry = {
   responseBody: { ok: true },
 };
 
+const rateLimitLogFixture: ApiLogEntry = {
+  id: 'log-rate-limit',
+  method: 'GET',
+  path: '/users',
+  fullUrl: 'https://mock.example.com/users',
+  origin: 'mock',
+  statusCode: 429,
+  latencyMs: 0,
+  scenario: 'rate-limit-block',
+  scenarioSelectionSource: 'rate-limit',
+  scenarioName: null,
+  hasScenario: false,
+  createdAt: '2026-04-08T10:00:02.000Z',
+  timeLabel: '10:00:02',
+  requestHeaders: {},
+  requestBody: null,
+  responseHeaders: { 'Retry-After': '55' },
+  responseBody: { error: 'Rate limit exceeded' },
+};
+
 describe('LogsDetailSidebarComponent', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -44,6 +64,18 @@ describe('LogsDetailSidebarComponent', () => {
 
     expect(component.executionSummary(noScenarioLogFixture)).toBe(
       'No scenario matched. Response came from the endpoint default payload.',
+    );
+  });
+
+  it('reports dedicated summary for rate-limit blocks', () => {
+    const injector = Injector.create({ providers: [...provideAngularReactiveSchedulers()] });
+    const component = runInInjectionContext(
+      injector,
+      () => new LogsDetailSidebarComponent(),
+    ) as unknown as LogsDetailSidebarHarness;
+
+    expect(component.executionSummary(rateLimitLogFixture)).toBe(
+      'Response blocked by project-wide runtime rate limiting.',
     );
   });
 });

--- a/apps/web/src/app/features/logs/components/logs-detail-sidebar/logs-detail-sidebar.component.ts
+++ b/apps/web/src/app/features/logs/components/logs-detail-sidebar/logs-detail-sidebar.component.ts
@@ -110,6 +110,7 @@ export class LogsDetailSidebarComponent {
         return 'detail__scenario-hero--success';
       case 'error':
       case 'forced-error':
+      case 'rate-limit-block':
       case 'timeout':
         return 'detail__scenario-hero--error';
       default:
@@ -126,6 +127,8 @@ export class LogsDetailSidebarComponent {
         return `Scenario ${label} selected from uniform random rules.`;
       case 'forced-error':
         return 'Response forced by global error simulation.';
+      case 'rate-limit':
+        return 'Response blocked by project-wide runtime rate limiting.';
       default:
         return log.hasScenario
           ? `Scenario ${label} selected directly from endpoint configuration.`

--- a/apps/web/src/app/features/logs/models/api-log.model.ts
+++ b/apps/web/src/app/features/logs/models/api-log.model.ts
@@ -2,10 +2,22 @@ import type { HttpMethod } from '../../../shared/models/endpoint-preview.model';
 
 export type LogOrigin = 'mock' | 'forced-error';
 
-export type LogScenarioKind = 'success' | 'error' | 'timeout' | 'empty' | 'forced-error' | 'default';
+export type LogScenarioKind =
+  | 'success'
+  | 'error'
+  | 'timeout'
+  | 'empty'
+  | 'forced-error'
+  | 'default'
+  | 'rate-limit-block';
 
 /** How the mock resolver picked the scenario (drives execution summary copy). */
-export type ScenarioSelectionSource = 'weighted-random' | 'uniform-random' | 'direct-endpoint' | 'forced-error';
+export type ScenarioSelectionSource =
+  | 'weighted-random'
+  | 'uniform-random'
+  | 'direct-endpoint'
+  | 'forced-error'
+  | 'rate-limit';
 
 export interface ApiLogCursor {
   createdAt: string;

--- a/apps/web/src/app/shared/http/api.types.ts
+++ b/apps/web/src/app/shared/http/api.types.ts
@@ -142,8 +142,8 @@ export interface ApiLogDto {
   origin: 'mock' | 'forced-error';
   statusCode: number;
   latencyMs: number;
-  scenarioType: 'success' | 'error' | 'timeout' | 'empty' | 'forced-error' | 'default';
-  scenarioSelectionSource: 'weighted-random' | 'uniform-random' | 'direct-endpoint' | 'forced-error';
+  scenarioType: 'success' | 'error' | 'timeout' | 'empty' | 'forced-error' | 'default' | 'rate-limit-block';
+  scenarioSelectionSource: 'weighted-random' | 'uniform-random' | 'direct-endpoint' | 'forced-error' | 'rate-limit';
   scenarioName: string | null;
   hasScenario: boolean;
   requestHeaders: Record<string, string>;


### PR DESCRIPTION
Closes #5

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- enforce the existing project rate limiting config inside the mock runtime with deterministic fixed-window behavior
- emit standard rate-limit headers and log blocked requests with explicit rate-limit metadata
- surface the new runtime metadata in logs/global config so the product reflects the project-wide MVP behavior

## Changes Table
| File | Change |
|------|--------|
| `apps/backend/src/mock-server/rate-limit.ts` | added the in-memory fixed-window rate limiter and deterministic test helpers |
| `apps/backend/src/mock-server/mock.router.ts` | wired runtime enforcement before scenario/error/latency handling and returned 429 responses with rate-limit headers |
| `apps/backend/src/__tests__/app.integration.test.ts` | added runtime tests for allow/exhaust/reset, bypass when disabled, and scope invariants |
| `apps/web/src/app/features/logs/*` | preserved and displayed rate-limit metadata in logs and the detail sidebar |
| `apps/web/src/app/features/global-config/components/global-config-drawer/global-config-drawer.component.html` | clarified the project-wide runtime scope in the existing UI copy |

## Test Plan
- [x] Backend runtime tests executed for allow/exhaust/reset, disabled bypass, scope invariant, headers, and logging metadata
- [x] Frontend logs mapping/sidebar tests executed for rate-limit metadata rendering
- [x] Relevant backend typecheck and lint checks executed without running a full build

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran relevant automated tests for the changed areas
- [x] Docs update not required for this behavior change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers