### PR TITLE
docs: improve monorepo onboarding and local environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,24 @@
 
 Monorepo para diseñar, administrar y ejecutar APIs mockeadas con soporte para proyectos, endpoints, escenarios, configuración global, logs y generación asistida por IA.
 
-El repo está dividido en dos aplicaciones principales:
+## Qué incluye este monorepo
 
-- **`apps/web`**: interfaz Angular para operar el simulador
-- **`apps/backend`**: API de gestión + runtime de mocks + persistencia
+- **`apps/backend`**: API de gestión, runtime de mocks y persistencia con Prisma/PostgreSQL.
+- **`apps/web`**: interfaz Angular para operar el simulador desde navegador.
+- **`docs/sdd`**: artefactos del flujo Spec-Driven Development usado por el proyecto.
+- **`libs`**: espacio reservado para código compartido.
 
 ## Estructura del repo
 
 ```text
 .
 ├── apps/
-│   ├── web/        # Frontend Angular 21
-│   └── backend/    # API backend + mock runtime + Prisma/PostgreSQL
+│   ├── backend/
+│   └── web/
 ├── docs/
-│   └── sdd/        # Artefactos y documentación del flujo SDD
-├── libs/           # Espacio para librerías compartidas
-└── .github/        # Workflows y automatización
+│   └── sdd/
+├── libs/
+└── .github/
 ```
 
 ## Stack
@@ -27,48 +29,71 @@ El repo está dividido en dos aplicaciones principales:
 - **Backend:** Node.js, Express 5, Prisma, PostgreSQL, Zod
 - **CI:** GitHub Actions
 
-## Qué podés hacer con el proyecto
+## Prerrequisitos
 
-- crear, editar y eliminar proyectos
-- definir endpoints manuales y escenarios
-- configurar comportamiento global del mock por proyecto
-- inspeccionar logs de requests simuladas
-- exponer mocks accesibles por URL
-- generar estructuras iniciales vía IA desde backend
-
-## Requisitos
-
-- Node.js 22+
-- pnpm 10+
-- Docker Desktop o PostgreSQL local
+- Node.js **22+**
+- pnpm **10+**
+- Docker Desktop **o** PostgreSQL local
 
 ## Instalación
 
-Desde la raíz:
+Desde la raíz del repo:
 
 ```bash
 pnpm install
 ```
 
-## Quick start local
+## Variables de entorno
 
-### 1. Levantar PostgreSQL
+### Backend
 
-La opción más simple y reproducible es usar Docker desde `apps/backend`:
+El backend carga variables desde `apps/backend/.env`.
+
+1. Copiá el ejemplo:
+
+   ```bash
+   cp apps/backend/.env.example apps/backend/.env
+   ```
+
+   > En PowerShell podés usar: `Copy-Item apps/backend/.env.example apps/backend/.env`
+
+2. Valores disponibles:
+
+| Variable         | Obligatoria                          | Uso                                                                |
+| ---------------- | ------------------------------------ | ------------------------------------------------------------------ |
+| `DATABASE_URL`   | Sí                                   | Conexión Prisma/PostgreSQL para desarrollo local                   |
+| `OPENAI_API_KEY` | No para boot, sí para probar IA real | Si no vas a probar IA, podés dejar una dummy                       |
+| `OPENAI_MODEL`   | No                                   | Modelo usado por backend para features asistidas por IA            |
+| `MOCK_BASE_URL`  | No                                   | Base pública que el backend usa al construir URLs del mock runtime |
+| `PORT`           | No                                   | Puerto HTTP del backend                                            |
+| `NODE_ENV`       | No                                   | Entorno de ejecución                                               |
+
+### Frontend
+
+Hoy el frontend **no usa un `.env` propio**. Por defecto consume el backend en `http://localhost:3000` desde `apps/web/src/app/shared/config/api.config.ts`.
+
+## Setup local paso a paso
+
+### 1. Levantar PostgreSQL con Docker
+
+La opción más simple es reutilizar el compose del backend:
 
 ```bash
-cd apps/backend
-docker compose -f docker-compose.test.yml up -d
+pnpm --dir apps/backend db:test:up
 ```
 
-### 2. Configurar backend
+Eso expone PostgreSQL en `localhost:54329`.
 
-Asegurate de tener un `.env` válido en `apps/backend/.env`.
+> El compose crea por default la base `simulador_api_test`. Para desarrollo local del backend conviene usar otra base, por ejemplo `simulador_api`, en el mismo servidor.
 
-Ejemplo mínimo:
+### 2. Configurar el backend
+
+Copiá `apps/backend/.env.example` a `apps/backend/.env` y ajustá al menos `DATABASE_URL`.
+
+Ejemplo local:
 
 ```env
-DATABASE_URL="postgresql://postgres:postgres@localhost:54329/simulador_api"
+DATABASE_URL="postgresql://postgres:postgres@localhost:54329/simulador_api?schema=public"
 OPENAI_API_KEY="test-key-local-dev"
 OPENAI_MODEL="gpt-4.1-mini"
 MOCK_BASE_URL="http://localhost:3000/mock"
@@ -76,36 +101,52 @@ PORT=3000
 NODE_ENV=development
 ```
 
-Aplicá migraciones:
+Después aplicá migraciones:
 
 ```bash
+pnpm --dir apps/backend prisma:generate
 pnpm --dir apps/backend exec prisma migrate deploy --schema prisma/schema.prisma
 ```
 
-Levantá el backend:
+### 3. Levantar backend
 
 ```bash
 pnpm --dir apps/backend dev
 ```
 
-Backend local:
+URLs locales:
 
 - API: `http://localhost:3000`
 - Health: `http://localhost:3000/health`
+- Mock runtime base: `http://localhost:3000/mock`
 
-### 3. Levantar frontend
+### 4. Levantar frontend
 
-Levantá el frontend:
+En otra terminal:
 
 ```bash
-pnpm --dir apps/web exec ng serve --host 127.0.0.1 --port 4200 --no-open
+pnpm --dir apps/web start -- --host 127.0.0.1 --port 4200 --no-open
 ```
 
 Frontend local:
 
 - Web: `http://127.0.0.1:4200`
 
-## Scripts útiles
+## Docker y base de datos
+
+Comandos útiles del backend:
+
+```bash
+pnpm --dir apps/backend db:test:up
+pnpm --dir apps/backend db:test:down
+pnpm --dir apps/backend prisma:generate
+pnpm --dir apps/backend prisma:migrate
+pnpm --dir apps/backend prisma:studio
+```
+
+Si usás PostgreSQL local en vez de Docker, solo asegurate de que `DATABASE_URL` apunte a una base existente y luego corré migraciones.
+
+## Comandos útiles del workspace
 
 ### Raíz
 
@@ -113,16 +154,9 @@ Frontend local:
 pnpm lint
 pnpm format:check
 pnpm test
-```
-
-### Frontend
-
-```bash
-pnpm --dir apps/web start
-pnpm --dir apps/web build
-pnpm --dir apps/web test
-pnpm --dir apps/web exec tsc --project tsconfig.app.json --noEmit
-pnpm --dir apps/web exec tsc --project tsconfig.spec.json --noEmit
+pnpm test:coverage
+pnpm test:coverage:backend
+pnpm test:coverage:web
 ```
 
 ### Backend
@@ -134,28 +168,41 @@ pnpm --dir apps/backend test
 pnpm --dir apps/backend test:db
 pnpm --dir apps/backend prisma:generate
 pnpm --dir apps/backend prisma:migrate
+pnpm --dir apps/backend prisma:studio
 ```
 
-## CI actual
+### Frontend
 
-El workflow principal valida:
+```bash
+pnpm --dir apps/web start
+pnpm --dir apps/web test
+pnpm --dir apps/web test:coverage
+pnpm --dir apps/web exec tsc --project tsconfig.app.json --noEmit
+pnpm --dir apps/web exec tsc --project tsconfig.spec.json --noEmit
+```
 
-- backend lint + tests
-- frontend lint + typecheck app/spec + tests headless
-- integración backend con DB
-- shellcheck
+## Troubleshooting rápido
+
+- **`DATABASE_URL` inválida o base inexistente** → Prisma no va a migrar ni arrancar. Verificá host, puerto, credenciales y nombre de base.
+- **Docker levantó solo `simulador_api_test`** → creá una base de desarrollo separada o apuntá conscientemente a la de tests si sabés lo que estás haciendo.
+- **El frontend no conecta** → revisá que el backend esté corriendo en `http://localhost:3000` o ajustá `apps/web/src/app/shared/config/api.config.ts`.
+- **La funcionalidad de IA falla** → el backend arranca sin `OPENAI_API_KEY`, pero las rutas de IA van a responder como no disponibles si no configurás una key real.
+- **No mezcles `npm` con `pnpm`** → el workspace está pensado para pnpm; evitá generar `package-lock.json`.
 
 ## Flujo recomendado de trabajo
 
-1. levantar backend y frontend en local
-2. validar cambios con tests/checks acotados por app
-3. abrir PR contra `dev`
-4. dejar que CI valide frontend y backend
+1. instalar dependencias con `pnpm install`
+2. levantar PostgreSQL
+3. configurar `apps/backend/.env`
+4. correr migraciones del backend
+5. levantar backend y frontend
+6. validar cambios con lint/tests acotados
+7. abrir PR contra `dev`
 
 ## Documentación por app
 
-- [Frontend (`apps/web/README.md`)](apps/web/README.md)
 - [Backend (`apps/backend/README.md`)](apps/backend/README.md)
+- [Frontend (`apps/web/README.md`)](apps/web/README.md)
 
 ## Endpoints principales del backend
 
@@ -171,7 +218,6 @@ El workflow principal valida:
 
 ## Notas importantes
 
-- El repo usa **pnpm**; evitá mezclarlo con `npm` o `package-lock.json`.
-- La integración con OpenAI requiere una key real si querés usar IA de verdad.
-- Los cambios grandes del repo se vienen trabajando con **SDD (Spec-Driven Development)**.
 - La rama de integración del equipo hoy es **`dev`**.
+- La CI valida lint y tests de backend/frontend, más integración del backend con DB.
+- Los cambios grandes del repo se vienen trabajando con **SDD (Spec-Driven Development)**.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,0 +1,6 @@
+DATABASE_URL="postgresql://postgres:postgres@localhost:54329/simulador_api?schema=public"
+OPENAI_API_KEY="test-key-local-dev"
+OPENAI_MODEL="gpt-4.1-mini"
+MOCK_BASE_URL="http://localhost:3000/mock"
+PORT=3000
+NODE_ENV=development

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -34,10 +34,18 @@ apps/backend/src/
 
 ## Variables de entorno
 
-Copiá o creá `apps/backend/.env` y definí al menos:
+El backend carga variables desde `apps/backend/.env`.
+
+```bash
+cp apps/backend/.env.example apps/backend/.env
+```
+
+> En PowerShell: `Copy-Item apps/backend/.env.example apps/backend/.env`
+
+Ejemplo base:
 
 ```env
-DATABASE_URL="postgresql://postgres:postgres@localhost:54329/simulador_api"
+DATABASE_URL="postgresql://postgres:postgres@localhost:54329/simulador_api?schema=public"
 OPENAI_API_KEY="test-key-local-dev"
 OPENAI_MODEL="gpt-4.1-mini"
 MOCK_BASE_URL="http://localhost:3000/mock"
@@ -48,27 +56,28 @@ NODE_ENV=development
 ### Notas
 
 - `DATABASE_URL` es obligatoria.
-- `OPENAI_API_KEY` hoy también es requerida al arrancar; para desarrollo local puede usarse una dummy si no vas a probar IA real.
-- `MOCK_BASE_URL` define la base usada para URLs del mock runtime.
+- `OPENAI_API_KEY` puede quedar dummy en desarrollo si no vas a probar IA real.
+- `OPENAI_MODEL`, `MOCK_BASE_URL`, `PORT` y `NODE_ENV` tienen defaults en código, pero conviene dejarlos explícitos en `.env` para onboarding.
 
 ## Base de datos local
 
-El repo ya trae un compose reutilizable:
+El repo trae un compose reutilizable:
 
 ```bash
-cd apps/backend
-docker compose -f docker-compose.test.yml up -d
+pnpm --dir apps/backend db:test:up
 ```
 
-Eso levanta PostgreSQL en `localhost:54329`.
+Eso levanta PostgreSQL en `localhost:54329` y crea la base `simulador_api_test`.
 
-Si necesitás la base `simulador_api`, creala dentro del contenedor y después aplicá migraciones.
+Para desarrollo local del backend, creá además una base como `simulador_api` y apuntá `DATABASE_URL` a esa base.
 
 ## Arranque local
 
-Desde la raíz:
+Desde la raíz del monorepo:
 
 ```bash
+pnpm --dir apps/backend prisma:generate
+pnpm --dir apps/backend exec prisma migrate deploy --schema prisma/schema.prisma
 pnpm --dir apps/backend dev
 ```
 
@@ -77,6 +86,11 @@ Servidor local:
 ```text
 http://localhost:3000
 ```
+
+Endpoints útiles:
+
+- `GET /health`
+- `ANY /mock/:projectSlug/*`
 
 ## Migraciones y Prisma
 
@@ -91,10 +105,9 @@ pnpm --dir apps/backend prisma:studio
 
 ```bash
 pnpm --dir apps/backend dev
-pnpm --dir apps/backend build
-pnpm --dir apps/backend start
 pnpm --dir apps/backend lint
 pnpm --dir apps/backend test
+pnpm --dir apps/backend test:coverage
 pnpm --dir apps/backend test:watch
 pnpm --dir apps/backend test:db
 pnpm --dir apps/backend db:test:up
@@ -119,18 +132,6 @@ postgresql://postgres:postgres@localhost:54329/simulador_api_test?schema=public
 
 Podés overridear con `DATABASE_URL_TEST`.
 
-## Endpoints clave
-
-- `GET /health`
-- `GET/POST/PATCH/DELETE /api/v1/projects`
-- `GET/POST/PATCH/DELETE /api/v1/projects/:projectId/endpoints`
-- `GET/POST/PATCH/DELETE /api/v1/endpoints/:endpointId/scenarios`
-- `GET/PUT /api/v1/endpoints/:endpointId/config`
-- `GET/PUT /api/v1/projects/:projectId/config`
-- `GET/DELETE /api/v1/projects/:projectId/logs`
-- `POST /api/v1/projects/:projectId/endpoints/ai-generate`
-- `ANY /mock/:projectSlug/*`
-
 ## Dónde tocar según el caso
 
 - **API y bootstrap**: `src/app.ts`, `src/server.ts`
@@ -143,6 +144,5 @@ Podés overridear con `DATABASE_URL_TEST`.
 ## Consideraciones actuales
 
 - el mock runtime todavía tiene deuda entre config expuesta y comportamiento real en algunas opciones avanzadas
-- el backend ya soporta edición y eliminación de proyectos
-- el flujo de IA existe en backend, pero todavía hay deuda de alineación end-to-end con frontend
+- el flujo de IA existe en backend, pero sin `OPENAI_API_KEY` real las rutas asistidas van a responder como no disponibles
 - la CI del repo valida lint, tests e integración DB del backend


### PR DESCRIPTION
Closes #10

## PR Type
- [ ] Bug fix
- [ ] New feature
- [x] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- reorganize the root onboarding guide so new contributors can install dependencies, configure env vars, start backend/frontend, and understand the local Postgres flow from one place
- add a backend .env.example with realistic local defaults and align the backend README with the documented Docker + Prisma workflow
- document current frontend env constraints explicitly instead of implying a non-existent .env flow

## Changes
| File | Change |
|------|--------|
| README.md | expands the monorepo onboarding guide with prerequisites, env setup, Docker/Postgres steps, startup flow, commands, and troubleshooting |
| pps/backend/README.md | aligns backend setup docs with .env.example, Prisma workflow, and DB guidance |
| pps/backend/.env.example | adds a copyable local backend env template |

## Test Plan
- [x] Ran pnpm exec prettier --check README.md apps/backend/README.md
- [x] Manually reviewed the docs flow from fresh-clone onboarding perspective
- [x] No shell scripts were modified

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one 	ype:* label
- [x] Ran shellcheck on modified scripts (not applicable, no scripts changed)
- [x] Skills tested in at least one agent (not applicable, no skill changes)
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No Co-Authored-By trailers