### PR TITLE
refactor(ai): decouple OpenAI env validation from backend startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ El backend carga variables desde `apps/backend/.env`.
 | Variable         | Obligatoria                          | Uso                                                                |
 | ---------------- | ------------------------------------ | ------------------------------------------------------------------ |
 | `DATABASE_URL`   | Sí                                   | Conexión Prisma/PostgreSQL para desarrollo local                   |
-| `OPENAI_API_KEY` | No para boot, sí para probar IA real | Si no vas a probar IA, podés dejar una dummy                       |
+| `OPENAI_API_KEY` | No para boot, sí para probar IA real | Solo hace falta si vas a usar endpoints asistidos por IA           |
 | `OPENAI_MODEL`   | No                                   | Modelo usado por backend para features asistidas por IA            |
 | `MOCK_BASE_URL`  | No                                   | Base pública que el backend usa al construir URLs del mock runtime |
 | `PORT`           | No                                   | Puerto HTTP del backend                                            |
@@ -94,7 +94,6 @@ Ejemplo local:
 
 ```env
 DATABASE_URL="postgresql://postgres:postgres@localhost:54329/simulador_api?schema=public"
-OPENAI_API_KEY="test-key-local-dev"
 OPENAI_MODEL="gpt-4.1-mini"
 MOCK_BASE_URL="http://localhost:3000/mock"
 PORT=3000

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,5 +1,4 @@
 DATABASE_URL="postgresql://postgres:postgres@localhost:54329/simulador_api?schema=public"
-OPENAI_API_KEY="test-key-local-dev"
 OPENAI_MODEL="gpt-4.1-mini"
 MOCK_BASE_URL="http://localhost:3000/mock"
 PORT=3000

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -46,7 +46,6 @@ Ejemplo base:
 
 ```env
 DATABASE_URL="postgresql://postgres:postgres@localhost:54329/simulador_api?schema=public"
-OPENAI_API_KEY="test-key-local-dev"
 OPENAI_MODEL="gpt-4.1-mini"
 MOCK_BASE_URL="http://localhost:3000/mock"
 PORT=3000
@@ -56,7 +55,7 @@ NODE_ENV=development
 ### Notas
 
 - `DATABASE_URL` es obligatoria.
-- `OPENAI_API_KEY` puede quedar dummy en desarrollo si no vas a probar IA real.
+- `OPENAI_API_KEY` es opcional para boot. Solo configurala si vas a usar endpoints asistidos por IA.
 - `OPENAI_MODEL`, `MOCK_BASE_URL`, `PORT` y `NODE_ENV` tienen defaults en código, pero conviene dejarlos explícitos en `.env` para onboarding.
 
 ## Base de datos local

--- a/apps/backend/src/__tests__/app.integration.test.ts
+++ b/apps/backend/src/__tests__/app.integration.test.ts
@@ -119,7 +119,6 @@ function buildMockEndpoint(overrides: Record<string, unknown> = {}) {
 describe('app integration', () => {
   beforeAll(async () => {
     process.env.DATABASE_URL ??= 'postgresql://user:password@localhost:5432/simulador_api_ia_test';
-    process.env.OPENAI_API_KEY ??= 'test-key';
     process.env.OPENAI_MODEL ??= 'gpt-4.1-mini';
 
     ({ app } = await import('../app.js'));

--- a/apps/backend/src/__tests__/db.integration.test.ts
+++ b/apps/backend/src/__tests__/db.integration.test.ts
@@ -80,7 +80,6 @@ describeDb('db integration (real postgres)', () => {
     process.env.NODE_ENV = 'test';
     process.env.DATABASE_URL ??=
       'postgresql://postgres:postgres@localhost:54329/simulador_api_test?schema=public';
-    process.env.OPENAI_API_KEY ??= 'test-key';
     process.env.OPENAI_MODEL ??= 'gpt-4.1-mini';
 
     ({ app } = await import('../app.js'));

--- a/apps/backend/src/config/env.test.ts
+++ b/apps/backend/src/config/env.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnv } from './env.js';
+
+const baseEnv = {
+  DATABASE_URL: 'postgresql://postgres:postgres@localhost:54329/simulador_api?schema=public',
+  NODE_ENV: 'test' as const,
+};
+
+describe('parseEnv', () => {
+  it('permite boot sin credenciales de OpenAI y normaliza strings vacíos', () => {
+    const parsed = parseEnv({
+      ...baseEnv,
+      OPENAI_API_KEY: '   ',
+      OPENAI_MODEL: '   ',
+    });
+
+    expect(parsed.OPENAI_API_KEY).toBeUndefined();
+    expect(parsed.OPENAI_MODEL).toBe('gpt-4.1-mini');
+  });
+
+  it('preserva configuración válida de OpenAI cuando existe', () => {
+    const parsed = parseEnv({
+      ...baseEnv,
+      OPENAI_API_KEY: 'test-key',
+      OPENAI_MODEL: 'gpt-4.1-mini',
+    });
+
+    expect(parsed.OPENAI_API_KEY).toBe('test-key');
+    expect(parsed.OPENAI_MODEL).toBe('gpt-4.1-mini');
+  });
+});

--- a/apps/backend/src/config/env.test.ts
+++ b/apps/backend/src/config/env.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it } from 'vitest';
-import { parseEnv } from './env.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { parseEnv as parseEnvFn } from './env.js';
 
 const baseEnv = {
   DATABASE_URL: 'postgresql://postgres:postgres@localhost:54329/simulador_api?schema=public',
   NODE_ENV: 'test' as const,
 };
+
+let parseEnv: typeof parseEnvFn;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= baseEnv.DATABASE_URL;
+  ({ parseEnv } = await import('./env.js'));
+});
 
 describe('parseEnv', () => {
   it('permite boot sin credenciales de OpenAI y normaliza strings vacíos', () => {

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -7,14 +7,39 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 loadEnv({ path: resolve(__dirname, '../../.env') });
 
+const optionalNonEmptyString = z.preprocess((value) => {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed === '' ? undefined : trimmed;
+}, z.string().min(1).optional());
+
+const defaultedNonEmptyString = (fallback: string) =>
+  z.preprocess((value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed === '' ? undefined : trimmed;
+  }, z.string().min(1).default(fallback));
+
 const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().default(3000),
   DATABASE_URL: z.string().min(1),
-  OPENAI_API_KEY: z.string().min(1).optional(),
-  OPENAI_MODEL: z.string().min(1).default('gpt-4.1-mini'),
+  OPENAI_API_KEY: optionalNonEmptyString,
+  OPENAI_MODEL: defaultedNonEmptyString('gpt-4.1-mini'),
   MOCK_BASE_URL: z.string().url().default('http://localhost:3000/mock'),
 });
 
-export const env = envSchema.parse(process.env);
+export function parseEnv(input: NodeJS.ProcessEnv): Env {
+  return envSchema.parse(input);
+}
+
+export const env = parseEnv(process.env);
 export type Env = z.infer<typeof envSchema>;


### PR DESCRIPTION
Closes #6

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [x] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- stop backend boot from depending on OPENAI_API_KEY by normalizing blank AI env values and defaulting the model during env parsing
- keep AI behavior lazy so routes still fail at runtime when exercised without valid OpenAI credentials
- update backend docs/examples and tests to reflect that OpenAI config is optional for startup

## Changes
| File | Change |
|------|--------|
| pps/backend/src/config/env.ts | makes AI-only env parsing lazy-friendly and exports parseEnv() for direct tests |
| pps/backend/src/config/env.test.ts | adds regression tests for optional OpenAI boot configuration |
| pps/backend/src/__tests__/app.integration.test.ts | removes unnecessary OpenAI key bootstrap dependency |
| pps/backend/src/__tests__/db.integration.test.ts | removes unnecessary OpenAI key bootstrap dependency |
| pps/backend/.env.example | removes the dummy OpenAI key from default local env template |
| pps/backend/README.md | documents OpenAI config as optional for boot |
| README.md | aligns monorepo onboarding docs with lazy AI startup |

## Test Plan
- [x] Ran pnpm --dir apps/backend test -- src/config/env.test.ts
- [x] Ran pnpm --dir apps/backend test -- src/__tests__/app.integration.test.ts
- [x] Ran pnpm --dir apps/backend lint
- [x] No shell scripts were modified

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one 	ype:* label
- [x] Ran shellcheck on modified scripts (not applicable, no scripts changed)
- [x] Skills tested in at least one agent (not applicable, no skill changes)
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No Co-Authored-By trailers