### PR TITLE
fix(mvp): align runtime config and unsupported UI flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,19 @@ El backend carga variables desde `apps/backend/.env`.
 
 ### Frontend
 
-Hoy el frontend **no usa un `.env` propio**. Por defecto consume el backend en `http://localhost:3000` desde `apps/web/src/app/shared/config/api.config.ts`.
+El frontend carga configuración runtime desde `apps/web/public/app-config.js`.
+
+- si no definís nada, usa defaults locales: `http://localhost:3000/api/v1` y `http://localhost:3000/mock`
+- si desplegás en otro entorno, podés reemplazar ese archivo sin rebuild y definir `window.__SIMULADOR_RUNTIME_CONFIG__`
+
+Ejemplo:
+
+```js
+window.__SIMULADOR_RUNTIME_CONFIG__ = {
+  apiBaseUrl: 'https://api.example.com/api/v1',
+  mockBaseUrl: 'https://api.example.com/mock',
+};
+```
 
 ## Setup local paso a paso
 
@@ -184,7 +196,7 @@ pnpm --dir apps/web exec tsc --project tsconfig.spec.json --noEmit
 
 - **`DATABASE_URL` inválida o base inexistente** → Prisma no va a migrar ni arrancar. Verificá host, puerto, credenciales y nombre de base.
 - **Docker levantó solo `simulador_api_test`** → creá una base de desarrollo separada o apuntá conscientemente a la de tests si sabés lo que estás haciendo.
-- **El frontend no conecta** → revisá que el backend esté corriendo en `http://localhost:3000` o ajustá `apps/web/src/app/shared/config/api.config.ts`.
+- **El frontend no conecta** → revisá que el backend esté corriendo en `http://localhost:3000` o ajustá `apps/web/public/app-config.js` para tu entorno.
 - **La funcionalidad de IA falla** → el backend arranca sin `OPENAI_API_KEY`, pero las rutas de IA van a responder como no disponibles si no configurás una key real.
 - **No mezcles `npm` con `pnpm`** → el workspace está pensado para pnpm; evitá generar `package-lock.json`.
 
@@ -212,6 +224,7 @@ pnpm --dir apps/web exec tsc --project tsconfig.spec.json --noEmit
 - `GET/PUT /api/v1/endpoints/:endpointId/config`
 - `GET/PUT /api/v1/projects/:projectId/config`
 - `GET/DELETE /api/v1/projects/:projectId/logs`
+- `POST /api/v1/projects/:projectId/endpoints/ai-preview`
 - `POST /api/v1/projects/:projectId/endpoints/ai-generate`
 - `ANY /mock/:projectSlug/*`
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -16,7 +16,7 @@ API backend y runtime de mocks del simulador. Maneja proyectos, endpoints, escen
 - persistir proyectos y recursos asociados
 - servir el mock runtime por proyecto
 - registrar logs de requests
-- generar estructuras de endpoints vía IA
+- generar borradores de endpoints vía IA (`ai-preview`) y persistir endpoints asistidos (`ai-generate`)
 
 ## Estructura principal
 
@@ -142,6 +142,9 @@ Podés overridear con `DATABASE_URL_TEST`.
 
 ## Consideraciones actuales
 
-- el mock runtime todavía tiene deuda entre config expuesta y comportamiento real en algunas opciones avanzadas
-- el flujo de IA existe en backend, pero sin `OPENAI_API_KEY` real las rutas asistidas van a responder como no disponibles
+- el MVP canoniza opciones todavía no soportadas: `GlobalConfig.scope` siempre se persiste como `all` y `EndpointConfig.errorRate` siempre vuelve en `0`
+- cuando la latencia global está habilitada, aplica a todo el runtime del proyecto aunque existan valores legacy de `scope`
+- la UI mantiene esos controles visibles pero deshabilitados y marcados como `Próximamente` para no prometer soporte inexistente
+- el backend expone dos rutas asistidas por IA: `POST /api/v1/projects/:projectId/endpoints/ai-preview` devuelve un draft normalizado sin persistir y `POST /api/v1/projects/:projectId/endpoints/ai-generate` crea el endpoint completo
+- sin `OPENAI_API_KEY` real, ambas rutas asistidas van a responder como no disponibles
 - la CI del repo valida lint, tests e integración DB del backend

--- a/apps/backend/src/__tests__/app.integration.test.ts
+++ b/apps/backend/src/__tests__/app.integration.test.ts
@@ -583,6 +583,112 @@ describe('app integration', () => {
     expect(blocked.headers['retry-after']).toBe('55');
   });
 
+  it('PUT /api/v1/projects/:projectId/config canonicaliza scope no soportado a all', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1' });
+    prismaMock.globalConfig.upsert.mockResolvedValueOnce({
+      projectId: 'p1',
+      latencyEnabled: false,
+      latencyMinMs: 0,
+      latencyMaxMs: 1000,
+      latencyMode: 'fixed',
+      errorSimulationEnabled: false,
+      errorSimulationRate: 0,
+      errorSimulationCodes: [500],
+      rateLimitingEnabled: false,
+      rateLimitingRpm: 60,
+      loggingLevel: 'basic',
+      scope: 'all',
+    });
+
+    const response = await request(app)
+      .put('/api/v1/projects/p1/config')
+      .send({
+        latencyEnabled: false,
+        latencyMinMs: 0,
+        latencyMaxMs: 1000,
+        latencyMode: 'fixed',
+        errorSimulationEnabled: false,
+        errorSimulationRate: 0,
+        errorSimulationCodes: [500],
+        rateLimitingEnabled: false,
+        rateLimitingRpm: 60,
+        loggingLevel: 'basic',
+        scope: 'unset',
+      });
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.globalConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ scope: 'all' }),
+        create: expect.objectContaining({ scope: 'all' }),
+      })
+    );
+    expect(response.body.scope).toBe('all');
+  });
+
+  it('PUT /api/v1/endpoints/:endpointId/config canonicaliza errorRate no soportado a 0', async () => {
+    prismaMock.endpoint.findUnique.mockResolvedValueOnce({ id: 'e1' });
+    prismaMock.endpointConfig.upsert.mockResolvedValueOnce({
+      endpointId: 'e1',
+      latencyMode: 'range',
+      fixedDelayMs: 0,
+      minDelayMs: 50,
+      maxDelayMs: 250,
+      errorRate: 0,
+      useScenarioWeights: false,
+    });
+
+    const response = await request(app).put('/api/v1/endpoints/e1/config').send({
+      latencyMode: 'range',
+      fixedDelayMs: 0,
+      minDelayMs: 50,
+      maxDelayMs: 250,
+      errorRate: 0.35,
+      useScenarioWeights: false,
+    });
+
+    expect(response.status).toBe(200);
+    expect(prismaMock.endpointConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ errorRate: 0 }),
+        create: expect.objectContaining({ errorRate: 0 }),
+      })
+    );
+    expect(response.body.errorRate).toBe(0);
+  });
+
+  it('GET /mock/:projectSlug/:path aplica latencia global aunque exista scope legacy distinto de all', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce(
+      buildMockProject({
+        globalConfig: {
+          ...buildMockProject().globalConfig,
+          latencyEnabled: true,
+          latencyMode: 'fixed',
+          latencyMinMs: 123,
+          latencyMaxMs: 456,
+          scope: 'unset',
+        },
+      })
+    );
+    prismaMock.endpoint.findFirst.mockResolvedValueOnce(
+      buildMockEndpoint({
+        endpointConfig: {
+          latencyMode: 'fixed',
+          fixedDelayMs: 25,
+          minDelayMs: 0,
+          maxDelayMs: 25,
+          useScenarioWeights: true,
+        },
+      })
+    );
+    prismaMock.apiLog.create.mockResolvedValueOnce({ id: 'l1' });
+
+    const response = await request(app).get('/mock/demo/users');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-simulador-latency']).toBe('123');
+  });
+
   it('GET /api/v1/projects/:projectId/logs devuelve últimos logs', async () => {
     prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1' });
     prismaMock.apiLog.findMany.mockResolvedValueOnce([

--- a/apps/backend/src/management/endpoint-config/service.ts
+++ b/apps/backend/src/management/endpoint-config/service.ts
@@ -2,6 +2,13 @@ import { prisma } from '../../lib/prisma.js';
 import { AppError } from '../../middleware/error-handler.js';
 import type { UpsertEndpointConfigInput } from './schema.js';
 
+function canonicalizeEndpointConfig(input: UpsertEndpointConfigInput): UpsertEndpointConfigInput {
+  return {
+    ...input,
+    errorRate: 0,
+  };
+}
+
 async function assertEndpointExists(endpointId: string): Promise<void> {
   const endpoint = await prisma.endpoint.findUnique({
     where: { id: endpointId },
@@ -38,24 +45,26 @@ export async function getEndpointConfig(endpointId: string) {
 export async function upsertEndpointConfig(endpointId: string, input: UpsertEndpointConfigInput) {
   await assertEndpointExists(endpointId);
 
+  const canonical = canonicalizeEndpointConfig(input);
+
   return prisma.endpointConfig.upsert({
     where: { endpointId },
     update: {
-      latencyMode: input.latencyMode,
-      fixedDelayMs: input.fixedDelayMs,
-      minDelayMs: input.minDelayMs,
-      maxDelayMs: input.maxDelayMs,
-      errorRate: input.errorRate,
-      useScenarioWeights: input.useScenarioWeights,
+      latencyMode: canonical.latencyMode,
+      fixedDelayMs: canonical.fixedDelayMs,
+      minDelayMs: canonical.minDelayMs,
+      maxDelayMs: canonical.maxDelayMs,
+      errorRate: canonical.errorRate,
+      useScenarioWeights: canonical.useScenarioWeights,
     },
     create: {
       endpointId,
-      latencyMode: input.latencyMode,
-      fixedDelayMs: input.fixedDelayMs,
-      minDelayMs: input.minDelayMs,
-      maxDelayMs: input.maxDelayMs,
-      errorRate: input.errorRate,
-      useScenarioWeights: input.useScenarioWeights,
+      latencyMode: canonical.latencyMode,
+      fixedDelayMs: canonical.fixedDelayMs,
+      minDelayMs: canonical.minDelayMs,
+      maxDelayMs: canonical.maxDelayMs,
+      errorRate: canonical.errorRate,
+      useScenarioWeights: canonical.useScenarioWeights,
     },
   });
 }

--- a/apps/backend/src/management/global-config/service.ts
+++ b/apps/backend/src/management/global-config/service.ts
@@ -4,6 +4,13 @@ import type { UpsertGlobalConfigInput } from './schema.js';
 export { buildDefaultGlobalConfig, DEFAULT_GLOBAL_CONFIG_VALUES } from './defaults.js';
 import { buildDefaultGlobalConfig } from './defaults.js';
 
+function canonicalizeGlobalConfig(input: UpsertGlobalConfigInput): UpsertGlobalConfigInput {
+  return {
+    ...input,
+    scope: 'all',
+  };
+}
+
 async function assertProjectExists(projectId: string): Promise<void> {
   const project = await prisma.project.findUnique({
     where: { id: projectId },
@@ -32,34 +39,36 @@ export async function getGlobalConfig(projectId: string) {
 export async function upsertGlobalConfig(projectId: string, input: UpsertGlobalConfigInput) {
   await assertProjectExists(projectId);
 
+  const canonical = canonicalizeGlobalConfig(input);
+
   return prisma.globalConfig.upsert({
     where: { projectId },
     update: {
-      latencyEnabled: input.latencyEnabled,
-      latencyMinMs: input.latencyMinMs,
-      latencyMaxMs: input.latencyMaxMs,
-      latencyMode: input.latencyMode,
-      errorSimulationEnabled: input.errorSimulationEnabled,
-      errorSimulationRate: input.errorSimulationRate,
-      errorSimulationCodes: input.errorSimulationCodes,
-      rateLimitingEnabled: input.rateLimitingEnabled,
-      rateLimitingRpm: input.rateLimitingRpm,
-      loggingLevel: input.loggingLevel,
-      scope: input.scope,
+      latencyEnabled: canonical.latencyEnabled,
+      latencyMinMs: canonical.latencyMinMs,
+      latencyMaxMs: canonical.latencyMaxMs,
+      latencyMode: canonical.latencyMode,
+      errorSimulationEnabled: canonical.errorSimulationEnabled,
+      errorSimulationRate: canonical.errorSimulationRate,
+      errorSimulationCodes: canonical.errorSimulationCodes,
+      rateLimitingEnabled: canonical.rateLimitingEnabled,
+      rateLimitingRpm: canonical.rateLimitingRpm,
+      loggingLevel: canonical.loggingLevel,
+      scope: canonical.scope,
     },
     create: {
       projectId,
-      latencyEnabled: input.latencyEnabled,
-      latencyMinMs: input.latencyMinMs,
-      latencyMaxMs: input.latencyMaxMs,
-      latencyMode: input.latencyMode,
-      errorSimulationEnabled: input.errorSimulationEnabled,
-      errorSimulationRate: input.errorSimulationRate,
-      errorSimulationCodes: input.errorSimulationCodes,
-      rateLimitingEnabled: input.rateLimitingEnabled,
-      rateLimitingRpm: input.rateLimitingRpm,
-      loggingLevel: input.loggingLevel,
-      scope: input.scope,
+      latencyEnabled: canonical.latencyEnabled,
+      latencyMinMs: canonical.latencyMinMs,
+      latencyMaxMs: canonical.latencyMaxMs,
+      latencyMode: canonical.latencyMode,
+      errorSimulationEnabled: canonical.errorSimulationEnabled,
+      errorSimulationRate: canonical.errorSimulationRate,
+      errorSimulationCodes: canonical.errorSimulationCodes,
+      rateLimitingEnabled: canonical.rateLimitingEnabled,
+      rateLimitingRpm: canonical.rateLimitingRpm,
+      loggingLevel: canonical.loggingLevel,
+      scope: canonical.scope,
     },
   });
 }

--- a/apps/backend/src/mock-server/latency.ts
+++ b/apps/backend/src/mock-server/latency.ts
@@ -10,7 +10,6 @@ interface GlobalLatencyConfig {
   latencyMode: string;
   latencyMinMs: number;
   latencyMaxMs: number;
-  scope: string;
 }
 
 function randomInt(min: number, max: number): number {
@@ -29,7 +28,7 @@ export function calculateLatency(
   endpointConfig: EndpointLatencyConfig | null,
   globalConfig: GlobalLatencyConfig | null
 ): number {
-  if (globalConfig?.latencyEnabled && globalConfig.scope === 'all') {
+  if (globalConfig?.latencyEnabled) {
     if (globalConfig.latencyMode === 'range') {
       return Math.min(randomInt(globalConfig.latencyMinMs, globalConfig.latencyMaxMs), 30_000);
     }

--- a/apps/backend/src/mock-server/mock.router.ts
+++ b/apps/backend/src/mock-server/mock.router.ts
@@ -125,7 +125,6 @@ async function resolveMockRequest(req: Request, res: Response, next: NextFunctio
           latencyMode: project.globalConfig.latencyMode,
           latencyMinMs: project.globalConfig.latencyMinMs,
           latencyMaxMs: project.globalConfig.latencyMaxMs,
-          scope: project.globalConfig.scope,
         }
       : null;
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -14,6 +14,7 @@ Aplicación Angular 21 del simulador. Es la UI principal para gestionar proyecto
 - dashboard principal de proyectos
 - workspace del proyecto activo
 - gestión de endpoints manuales
+- flujo asistido por IA para previsualizar borradores de endpoints y generar el primer endpoint de un proyecto
 - edición y eliminación de proyectos
 - configuración global
 - visualización de logs
@@ -54,9 +55,23 @@ http://127.0.0.1:4200
 
 ## Dependencia con backend
 
-La app espera backend disponible en `http://localhost:3000`.
+La app lee su configuración runtime desde `public/app-config.js`.
 
-Además, hoy deriva la mock URL desde esa base local. Si cambiás host o puerto, revisá `src/app/shared/config/api.config.ts`.
+Por default usa:
+
+- API: `http://localhost:3000/api/v1`
+- Mock runtime: `http://localhost:3000/mock`
+
+Si cambiás host, puerto o dominio para un deploy, podés reemplazar ese archivo sin rebuild:
+
+```js
+window.__SIMULADOR_RUNTIME_CONFIG__ = {
+  apiBaseUrl: 'https://api.example.com/api/v1',
+  mockBaseUrl: 'https://api.example.com/mock',
+};
+```
+
+Si omitís `mockBaseUrl`, el frontend intenta derivarlo desde `apiBaseUrl` reemplazando `/api/v1` por `/mock`.
 
 ## Scripts útiles
 
@@ -108,5 +123,5 @@ El workflow `CI` del repo corre un job dedicado **Frontend Validation** con:
 ## Limitaciones actuales
 
 - no hay build de producción dentro del gate inicial de CI
-- la URL del backend sigue acoplada a localhost en desarrollo
-- el flujo de IA todavía tiene deuda de alineación con backend real
+- la configuración runtime depende de que el hosting publique `app-config.js`
+- la creación asistida usa dos recorridos distintos: el wizard de endpoints consume `ai-preview` para editar un draft antes de guardar y el modal de crear proyecto usa `ai-generate` para persistir el primer endpoint automáticamente

--- a/apps/web/public/app-config.js
+++ b/apps/web/public/app-config.js
@@ -1,0 +1,7 @@
+/* global window */
+
+window.__SIMULADOR_RUNTIME_CONFIG__ = {
+  // Override these values at deploy/runtime without rebuilding the Angular app.
+  // apiBaseUrl: 'https://api.example.com/api/v1',
+  // mockBaseUrl: 'https://api.example.com/mock',
+};

--- a/apps/web/src/app/features/endpoints/adapters/endpoint-api.mapper.spec.ts
+++ b/apps/web/src/app/features/endpoints/adapters/endpoint-api.mapper.spec.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { mapAiDraftFromApi, mapEndpointDraftFromApi, mapEndpointSummaryFromApi } from './endpoint-api.mapper';
+import {
+  mapAiDraftFromApi,
+  mapEndpointConfigRequestFromDraft,
+  mapEndpointDraftFromApi,
+  mapEndpointSummaryFromApi,
+} from './endpoint-api.mapper';
 
 describe('endpoint-api.mapper', () => {
-  it('maps unsupported methods defensively and derives config percentages', () => {
+  it('maps unsupported methods defensively and zeroes unsupported endpoint error rate', () => {
     const result = mapEndpointSummaryFromApi({
       id: 'e1',
       projectId: 'p1',
@@ -25,7 +30,7 @@ describe('endpoint-api.mapper', () => {
 
     expect(result.method).toBe('GET');
     expect(result.config?.latencyMs).toBe(200);
-    expect(result.config?.errorRatePct).toBe(25);
+    expect(result.config?.errorRatePct).toBe(0);
   });
 
   it('hydrates edit draft using backend scenarios', () => {
@@ -61,8 +66,31 @@ describe('endpoint-api.mapper', () => {
     });
 
     expect(result.method).toBe('PATCH');
-    expect(result.behavior.errorRate).toBe(10);
+    expect(result.behavior.errorRate).toBe(0);
     expect(result.scenarios[0]?.id).toBe('s1');
+  });
+
+  it('forces endpoint config payloads to keep errorRate disabled in MVP', () => {
+    const result = mapEndpointConfigRequestFromDraft('e1', {
+      method: 'GET',
+      route: '/users',
+      description: 'List users',
+      statusCode: 200,
+      responseBody: { ok: true },
+      behavior: {
+        latencyMode: 'range',
+        fixedDelayMs: 0,
+        minDelayMs: 50,
+        maxDelayMs: 250,
+        errorRate: 35,
+        useScenarioWeights: true,
+      },
+      scenarios: [],
+      locks: { method: false, path: false, scenarioType: false },
+      source: 'manual',
+    });
+
+    expect(result.errorRate).toBe(0);
   });
 
   it('maps ai preview dto into a locked MVP draft without contract drift', () => {

--- a/apps/web/src/app/features/endpoints/adapters/endpoint-api.mapper.ts
+++ b/apps/web/src/app/features/endpoints/adapters/endpoint-api.mapper.ts
@@ -32,7 +32,7 @@ function configToUi(config?: EndpointConfigDto | null): EndpointConfig {
       resolved.latencyMode === 'range'
         ? Math.round((resolved.minDelayMs + resolved.maxDelayMs) / 2)
         : resolved.fixedDelayMs,
-    errorRatePct: Math.round(resolved.errorRate * 100),
+    errorRatePct: 0,
     scenarios: { success: true, empty: false, error: false, timeout: false },
   };
 }
@@ -83,7 +83,7 @@ export function mapEndpointDraftFromApi(endpoint: EndpointDto): EndpointDraft {
       fixedDelayMs: config?.fixedDelayMs ?? 0,
       minDelayMs: config?.minDelayMs ?? 0,
       maxDelayMs: config?.maxDelayMs ?? 500,
-      errorRate: Math.round((config?.errorRate ?? 0) * 100),
+      errorRate: 0,
       useScenarioWeights: config?.useScenarioWeights ?? true,
     },
     locks: unlockedEndpointDraftLocks(),
@@ -187,7 +187,7 @@ export function mapEndpointConfigRequestFromDraft(endpointId: string, draft: End
     fixedDelayMs: draft.behavior.fixedDelayMs,
     minDelayMs: draft.behavior.minDelayMs,
     maxDelayMs: draft.behavior.maxDelayMs,
-    errorRate: draft.behavior.errorRate / 100,
+    errorRate: 0,
     useScenarioWeights: draft.behavior.useScenarioWeights,
   };
 }

--- a/apps/web/src/app/features/endpoints/components/create-endpoint-editor-step/create-endpoint-editor-step.component.html
+++ b/apps/web/src/app/features/endpoints/components/create-endpoint-editor-step/create-endpoint-editor-step.component.html
@@ -229,9 +229,13 @@
             [min]="0"
             [max]="100"
             [step]="1"
+            [disabled]="true"
             (valueChange)="onErrorRateValue($event)"
           />
-          <p class="cep-editor__help">Percentage of requests that will randomly return an error scenario</p>
+          <p class="cep-editor__help">
+            Próximamente: el MVP todavía no soporta errores aleatorios por endpoint, así que este valor queda fijo en
+            0%.
+          </p>
           <div class="cep-editor__weight-row">
             <div>
               <span class="cep-editor__panel-title" style="margin: 0">Use scenario weights</span>

--- a/apps/web/src/app/features/endpoints/components/create-endpoint-page/create-endpoint-page.component.ts
+++ b/apps/web/src/app/features/endpoints/components/create-endpoint-page/create-endpoint-page.component.ts
@@ -307,15 +307,15 @@ export class CreateEndpointPageComponent {
   private mapGenerationError(error: unknown): string {
     if (error instanceof ApiError) {
       if (error.code === 'AI_TIMEOUT' || error.status === 504) {
-        return 'AI timed out before it could return a valid draft. Retry or continue manually.';
+        return 'AI timed out before it could return a valid draft. Retry to get a preview.';
       }
 
       if (error.code === 'AI_UNAVAILABLE' || error.status === 503) {
-        return 'AI is unavailable right now. Retry in a moment or continue manually.';
+        return 'AI is unavailable right now. Retry in a moment to get a preview.';
       }
 
       if (error.code === 'AI_INVALID_OUTPUT' || error.status === 422) {
-        return 'AI returned an invalid draft. Retry with a more explicit prompt or continue manually.';
+        return 'AI returned an invalid draft. Retry with a more explicit prompt to get a preview.';
       }
     }
 

--- a/apps/web/src/app/features/endpoints/components/create-endpoint-page/create-endpoint-page.integration.spec.ts
+++ b/apps/web/src/app/features/endpoints/components/create-endpoint-page/create-endpoint-page.integration.spec.ts
@@ -387,7 +387,7 @@ describe('CreateEndpointPageComponent integration', () => {
 
     expect(component.step()).toBe('prompt');
     expect(component.generationError()).toBe(
-      'AI timed out before it could return a valid draft. Retry or continue manually.',
+      'AI timed out before it could return a valid draft. Retry to get a preview.',
     );
     expect(component.generating()).toBe(false);
 
@@ -411,7 +411,7 @@ describe('CreateEndpointPageComponent integration', () => {
 
     expect(component.step()).toBe('prompt');
     expect(component.generationError()).toBe(
-      'AI returned an invalid draft. Retry with a more explicit prompt or continue manually.',
+      'AI returned an invalid draft. Retry with a more explicit prompt to get a preview.',
     );
     expect(component.generating()).toBe(false);
     expect(component.draft()).toBeNull();
@@ -429,7 +429,7 @@ describe('CreateEndpointPageComponent integration', () => {
     await component.onGenerateRequested();
 
     expect(component.step()).toBe('prompt');
-    expect(component.generationError()).toBe('AI is unavailable right now. Retry in a moment or continue manually.');
+    expect(component.generationError()).toBe('AI is unavailable right now. Retry in a moment to get a preview.');
     expect(component.generating()).toBe(false);
   });
 

--- a/apps/web/src/app/features/endpoints/data-access/endpoints.repository.spec.ts
+++ b/apps/web/src/app/features/endpoints/data-access/endpoints.repository.spec.ts
@@ -248,6 +248,7 @@ describe('EndpointsRepository', () => {
     );
 
     expect(api.patch).toHaveBeenCalledWith('/projects/p1/endpoints/e1', expect.any(Object));
+    expect(api.put).toHaveBeenCalledWith('/endpoints/e1/config', expect.objectContaining({ errorRate: 0 }));
     expect(api.patch).toHaveBeenCalledWith(
       '/endpoints/e1/scenarios/s1',
       expect.objectContaining({ name: 'Existing success' }),
@@ -255,7 +256,7 @@ describe('EndpointsRepository', () => {
     expect(api.post).toHaveBeenCalledWith('/endpoints/e1/scenarios', expect.objectContaining({ name: 'Timeout' }));
     expect(api.delete).toHaveBeenCalledWith('/endpoints/e1/scenarios/s-obsolete');
     expect(result.id).toBe('e1');
-    expect(result.config?.errorRatePct).toBe(15);
+    expect(result.config?.errorRatePct).toBe(0);
   });
 
   it('surfaces partial failures without refreshing endpoint detail', async () => {

--- a/apps/web/src/app/features/global-config/adapters/global-config-api.mapper.spec.ts
+++ b/apps/web/src/app/features/global-config/adapters/global-config-api.mapper.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { mapGlobalConfigFromApi, mapGlobalConfigToApi } from './global-config-api.mapper';
 
 describe('global-config-api.mapper', () => {
-  it('normalizes backend enums into frontend values', () => {
+  it('normalizes backend enums into frontend values and canonical MVP scope', () => {
     const result = mapGlobalConfigFromApi({
       projectId: 'p1',
       latencyEnabled: true,
@@ -21,10 +21,10 @@ describe('global-config-api.mapper', () => {
     expect(result.latency.mode).toBe('random');
     expect(result.errorSimulation.rate).toBe(15);
     expect(result.logging.level).toBe('none');
-    expect(result.scope).toBe('without-overrides');
+    expect(result.scope).toBe('all');
   });
 
-  it('maps frontend values back to backend payloads', () => {
+  it('maps frontend values back to backend payloads with canonical scope', () => {
     const result = mapGlobalConfigToApi({
       latency: { enabled: true, minMs: 10, maxMs: 50, mode: 'random' },
       errorSimulation: { enabled: true, rate: 20, statusCodes: [500] },
@@ -36,6 +36,6 @@ describe('global-config-api.mapper', () => {
     expect(result.latencyMode).toBe('range');
     expect(result.errorSimulationRate).toBe(0.2);
     expect(result.loggingLevel).toBe('full');
-    expect(result.scope).toBe('unset');
+    expect(result.scope).toBe('all');
   });
 });

--- a/apps/web/src/app/features/global-config/adapters/global-config-api.mapper.ts
+++ b/apps/web/src/app/features/global-config/adapters/global-config-api.mapper.ts
@@ -21,7 +21,7 @@ export function mapGlobalConfigFromApi(config: GlobalConfigDto): GlobalConfig {
     logging: {
       level: config.loggingLevel === 'full' ? 'verbose' : config.loggingLevel === 'off' ? 'none' : 'basic',
     },
-    scope: config.scope === 'unset' ? 'without-overrides' : 'all',
+    scope: 'all',
   };
 }
 
@@ -37,6 +37,6 @@ export function mapGlobalConfigToApi(config: GlobalConfig): SaveGlobalConfigDto 
     rateLimitingEnabled: config.rateLimiting.enabled,
     rateLimitingRpm: config.rateLimiting.requestsPerMinute,
     loggingLevel: config.logging.level === 'verbose' ? 'full' : config.logging.level === 'none' ? 'off' : 'basic',
-    scope: config.scope === 'without-overrides' ? 'unset' : 'all',
+    scope: 'all',
   };
 }

--- a/apps/web/src/app/features/global-config/components/global-config-drawer/global-config-drawer.component.html
+++ b/apps/web/src/app/features/global-config/components/global-config-drawer/global-config-drawer.component.html
@@ -259,7 +259,7 @@
                     name="gcfg-apply-scope"
                     value="all"
                     [checked]="state().scope === 'all'"
-                    (change)="setScope('all')"
+                    disabled
                   />
                   <span class="gcfg-radio__ui" aria-hidden="true"></span>
                   <span>All endpoints</span>
@@ -270,12 +270,15 @@
                     name="gcfg-apply-scope"
                     value="without-overrides"
                     [checked]="state().scope === 'without-overrides'"
-                    (change)="setScope('without-overrides')"
+                    disabled
                   />
                   <span class="gcfg-radio__ui" aria-hidden="true"></span>
                   <span>Only endpoints without custom configuration</span>
                 </label>
               </div>
+              <p class="gcfg-helper">
+                Próximamente: por ahora la configuración global siempre aplica a todo el proyecto.
+              </p>
             </div>
           </section>
         </div>

--- a/apps/web/src/app/features/global-config/data-access/global-config.repository.spec.ts
+++ b/apps/web/src/app/features/global-config/data-access/global-config.repository.spec.ts
@@ -42,8 +42,8 @@ describe('GlobalConfigRepository', () => {
       scope: 'without-overrides',
     });
 
-    expect(api.put).toHaveBeenCalled();
+    expect(api.put).toHaveBeenCalledWith('/projects/p1/config', expect.objectContaining({ scope: 'all' }));
     expect(result.logging.level).toBe('verbose');
-    expect(result.scope).toBe('without-overrides');
+    expect(result.scope).toBe('all');
   });
 });

--- a/apps/web/src/app/features/global-config/models/global-config.model.ts
+++ b/apps/web/src/app/features/global-config/models/global-config.model.ts
@@ -50,7 +50,7 @@ export function createDefaultGlobalConfig(): GlobalConfig {
     logging: {
       level: 'verbose',
     },
-    scope: 'without-overrides',
+    scope: 'all',
   };
 }
 

--- a/apps/web/src/app/features/logs/adapters/logs-api.mapper.spec.ts
+++ b/apps/web/src/app/features/logs/adapters/logs-api.mapper.spec.ts
@@ -8,7 +8,7 @@ describe('logs-api.mapper', () => {
       projectId: 'p1',
       method: 'HEAD',
       path: '/users',
-      fullUrl: 'http://localhost:3000/mock/users/users',
+      fullUrl: 'https://mock.example.com/users/users',
       origin: 'forced-error',
       statusCode: 504,
       latencyMs: 900,

--- a/apps/web/src/app/features/main-dashboard/adapters/project-api.mapper.spec.ts
+++ b/apps/web/src/app/features/main-dashboard/adapters/project-api.mapper.spec.ts
@@ -1,7 +1,24 @@
-import { describe, expect, it } from 'vitest';
-import { mapDashboardEndpointPreviewFromSummaryRow, mapDashboardProjectFromApi } from './project-api.mapper';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  mapCreatedProjectPlaceholder,
+  mapDashboardEndpointPreviewFromSummaryRow,
+  mapDashboardProjectFromApi,
+} from './project-api.mapper';
+
+type RuntimeConfigGlobal = typeof globalThis & {
+  __SIMULADOR_RUNTIME_CONFIG__?: {
+    apiBaseUrl?: string;
+    mockBaseUrl?: string;
+  };
+};
+
+const runtimeConfigGlobal = globalThis as RuntimeConfigGlobal;
 
 describe('project-api.mapper', () => {
+  afterEach(() => {
+    delete runtimeConfigGlobal.__SIMULADOR_RUNTIME_CONFIG__;
+  });
+
   it('maps backend summary data into dashboard shape', () => {
     const result = mapDashboardProjectFromApi({
       project: {
@@ -9,7 +26,7 @@ describe('project-api.mapper', () => {
         name: 'Users API',
         description: '',
         slug: 'users-api',
-        mockUrl: 'http://localhost:3000/mock/users-api',
+        mockUrl: 'https://mock.example.com/users-api',
         updatedAt: new Date().toISOString(),
         status: 'attention',
       },
@@ -60,7 +77,7 @@ describe('project-api.mapper', () => {
     });
 
     expect(result.status).toBe('attention');
-    expect(result.mockUrl).toBe('http://localhost:3000/mock/users-api');
+    expect(result.mockUrl).toBe('https://mock.example.com/users-api');
     expect(result.description).toBe('Your mock API workspace.');
     expect(result.metrics.totalScenarios).toBe(3);
     expect(result.health.errorScenarioEndpoints).toBe(1);
@@ -81,7 +98,7 @@ describe('project-api.mapper', () => {
         name: 'Empty API',
         description: 'Seedless',
         slug: 'empty-api',
-        mockUrl: 'http://localhost:3000/mock/empty-api',
+        mockUrl: 'https://mock.example.com/empty-api',
         updatedAt: new Date().toISOString(),
         status: 'empty',
       },
@@ -114,6 +131,23 @@ describe('project-api.mapper', () => {
     expect(result.recentRequests).toEqual([]);
     expect(result.configSummary.logging.level).toBe('basic');
     expect(result.endpoints).toEqual([]);
+  });
+
+  it('builds placeholder mock URLs from runtime config when the backend has not returned a summary yet', () => {
+    runtimeConfigGlobal.__SIMULADOR_RUNTIME_CONFIG__ = {
+      mockBaseUrl: 'https://deploy.example.com/mock',
+    };
+
+    const result = mapCreatedProjectPlaceholder({
+      id: 'p3',
+      name: 'Generated API',
+      slug: 'generated-api',
+      description: '',
+      updatedAt: new Date().toISOString(),
+      _count: { endpoints: 0 },
+    });
+
+    expect(result.mockUrl).toBe('https://deploy.example.com/mock/generated-api');
   });
 
   it('maps summary endpoint rows into navigation-only previews explicitly derived on the frontend', () => {

--- a/apps/web/src/app/features/main-dashboard/adapters/project-api.mapper.ts
+++ b/apps/web/src/app/features/main-dashboard/adapters/project-api.mapper.ts
@@ -1,9 +1,9 @@
 import type { DashboardProject } from '../models/dashboard-project.model';
 import type { EndpointPreview } from '../../../shared/models/endpoint-preview.model';
 import type { DashboardSummaryDto, ProjectDto } from '../../../shared/http/api.types';
+import { getMockBaseUrl } from '../../../shared/config/app-runtime-config';
 import { formatRelativeTime } from '../../../shared/utils/relative-time';
 
-const MOCK_BASE_URL = 'http://localhost:3000/mock';
 const HTTP_METHODS = new Set<EndpointPreview['method']>(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
 
 function normalizeMethod(method: string): EndpointPreview['method'] {
@@ -29,12 +29,14 @@ export function mapDashboardEndpointPreviewFromSummaryRow(
 }
 
 export function mapDashboardProjectFromApi(summary: DashboardSummaryDto): DashboardProject {
+  const mockBaseUrl = getMockBaseUrl();
+
   return {
     id: summary.project.id,
     name: summary.project.name,
     slug: summary.project.slug,
     status: summary.project.status,
-    mockUrl: summary.project.mockUrl || `${MOCK_BASE_URL}/${summary.project.slug}`,
+    mockUrl: summary.project.mockUrl || `${mockBaseUrl}/${summary.project.slug}`,
     description: summary.project.description || 'Your mock API workspace.',
     lastUpdatedRelative: formatRelativeTime(summary.project.updatedAt),
     metrics: summary.metrics,
@@ -55,12 +57,14 @@ export function mapDashboardProjectFromApi(summary: DashboardSummaryDto): Dashbo
 }
 
 export function mapCreatedProjectPlaceholder(project: ProjectDto): DashboardProject {
+  const mockBaseUrl = getMockBaseUrl();
+
   return {
     id: project.id,
     name: project.name,
     slug: project.slug,
     status: 'empty',
-    mockUrl: `${MOCK_BASE_URL}/${project.slug}`,
+    mockUrl: `${mockBaseUrl}/${project.slug}`,
     description: project.description || 'Your mock API workspace.',
     lastUpdatedRelative: formatRelativeTime(project.updatedAt),
     metrics: {

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-data/main-dashboard-data.component.spec.ts
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-data/main-dashboard-data.component.spec.ts
@@ -22,7 +22,7 @@ const projectFixture: DashboardProject = {
   name: 'Users API',
   slug: 'users-api',
   status: 'attention',
-  mockUrl: 'http://localhost:3000/mock/users-api',
+  mockUrl: 'https://mock.example.com/users-api',
   description: 'Real dashboard project',
   lastUpdatedRelative: 'just now',
   metrics: {

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.spec.ts
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.spec.ts
@@ -27,7 +27,7 @@ const projectFixture: DashboardProject = {
   name: 'Users API',
   slug: 'users-api',
   status: 'running',
-  mockUrl: 'http://localhost:3000/mock/users-api',
+  mockUrl: 'https://mock.example.com/users-api',
   description: 'Traffic-backed project',
   lastUpdatedRelative: 'just now',
   metrics: {

--- a/apps/web/src/app/features/main-dashboard/data-access/projects.repository.spec.ts
+++ b/apps/web/src/app/features/main-dashboard/data-access/projects.repository.spec.ts
@@ -19,7 +19,7 @@ const dashboardSummaryDto = {
     name: 'Users',
     description: '',
     slug: 'users',
-    mockUrl: 'http://localhost:3000/mock/users',
+    mockUrl: 'https://mock.example.com/users',
     updatedAt: new Date().toISOString(),
     status: 'running' as const,
   },
@@ -116,7 +116,7 @@ describe('ProjectsRepository', () => {
     expect(api.get).toHaveBeenCalledWith('/projects/p1/dashboard-summary');
     expect(result.name).toBe('Users v2');
     expect(result.metrics.totalScenarios).toBe(2);
-    expect(result.mockUrl).toBe('http://localhost:3000/mock/users');
+    expect(result.mockUrl).toBe('https://mock.example.com/users');
   });
 
   it('loads dashboard detail from the summary endpoint without endpoint fan-out', async () => {

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.html
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.html
@@ -128,13 +128,16 @@
 }
 
 @if (activeNav() === 'dashboard' && hasProjects()) {
-  <app-main-dashboard-utility-sidebar
-    (createEndpoint)="createEndpoint()"
-    (testAllEndpoints)="testAllEndpoints()"
-    (exportConfig)="exportConfig()"
-    (importEndpoints)="importEndpoints()"
-    (editGlobalConfig)="editGlobalConfig()"
-  />
+  @if (activeProject(); as project) {
+    <app-main-dashboard-utility-sidebar
+      [project]="project"
+      (createEndpoint)="createEndpoint()"
+      (testAllEndpoints)="testAllEndpoints()"
+      (exportConfig)="exportConfig()"
+      (importEndpoints)="importEndpoints()"
+      (editGlobalConfig)="editGlobalConfig()"
+    />
+  }
 } @else if (activeNav() === 'endpoints' && !createEndpointFlowOpen() && hasProjects()) {
   <app-endpoint-detail-panel
     [selectedEndpoint]="selectedEndpoint()"

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.spec.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.spec.ts
@@ -164,7 +164,7 @@ const normalizedConfigFixture: GlobalConfig = {
   errorSimulation: { enabled: true, rate: 15, statusCodes: [400, 500] },
   rateLimiting: { enabled: false, requestsPerMinute: 100 },
   logging: { level: 'none' },
-  scope: 'without-overrides',
+  scope: 'all',
 };
 
 describe('WorkspaceShellComponent', () => {
@@ -335,7 +335,7 @@ describe('WorkspaceShellComponent', () => {
     expect(component.globalConfigLoading()).toBe(false);
     expect(component.globalConfig()).toEqual(normalizedConfigFixture);
     expect(component.globalConfig().logging.level).toBe('none');
-    expect(component.globalConfig().scope).toBe('without-overrides');
+    expect(component.globalConfig().scope).toBe('all');
   });
 
   it('keeps the config drawer open and surfaces actionable feedback when save fails validation', async () => {

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.ts
@@ -1,19 +1,8 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
-import { CreateEndpointPageComponent } from '../endpoints/components/create-endpoint-page/create-endpoint-page.component';
-import { EndpointDetailPanelComponent } from '../endpoints/components/endpoint-detail-panel/endpoint-detail-panel.component';
-import { EndpointsPageComponent } from '../endpoints/endpoints-page.component';
-import { LogsComponent } from '../logs/logs.component';
-import { LogsDetailSidebarComponent } from '../logs/components/logs-detail-sidebar/logs-detail-sidebar.component';
-import { DashboardEmptyStateComponent } from '../main-dashboard/components/dashboard-empty-state/dashboard-empty-state.component';
-import { MainDashboardDataComponent } from '../main-dashboard/components/main-dashboard-data/main-dashboard-data.component';
-import { MainDashboardSidebarComponent } from '../main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component';
-import { MainDashboardUtilitySidebarComponent } from '../main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component';
-import { GlobalConfigDrawerComponent } from '../global-config/components/global-config-drawer/global-config-drawer.component';
-import { createDefaultGlobalConfig, type GlobalConfig } from '../global-config/models/global-config.model';
-import { GlobalConfigRepository } from '../global-config/data-access/global-config.repository';
-import { CreateProjectModalComponent } from '../../shared/ui/create-project-modal/create-project-modal.component';
-import { ConfirmDialogComponent } from '../../shared/ui/confirm-dialog/confirm-dialog.component';
 import { ApiError } from '../../shared/http/api-error.mapper';
+import type { EndpointPreview } from '../../shared/models/endpoint-preview.model';
+import { ConfirmDialogComponent } from '../../shared/ui/confirm-dialog/confirm-dialog.component';
+import { CreateProjectModalComponent } from '../../shared/ui/create-project-modal/create-project-modal.component';
 import type {
   CreateProjectModalPayload,
   CreateProjectWithEndpointPayload,
@@ -21,12 +10,23 @@ import type {
   ProjectModalInitialValues,
   ProjectModalMode,
 } from '../../shared/ui/create-project-modal/create-project-modal.model';
+import { CreateEndpointPageComponent } from '../endpoints/components/create-endpoint-page/create-endpoint-page.component';
+import { EndpointDetailPanelComponent } from '../endpoints/components/endpoint-detail-panel/endpoint-detail-panel.component';
+import { EndpointsRepository } from '../endpoints/data-access/endpoints.repository';
+import { EndpointsPageComponent } from '../endpoints/endpoints-page.component';
+import { GlobalConfigDrawerComponent } from '../global-config/components/global-config-drawer/global-config-drawer.component';
+import { GlobalConfigRepository } from '../global-config/data-access/global-config.repository';
+import { createDefaultGlobalConfig, type GlobalConfig } from '../global-config/models/global-config.model';
+import { LogsDetailSidebarComponent } from '../logs/components/logs-detail-sidebar/logs-detail-sidebar.component';
+import { LogsComponent } from '../logs/logs.component';
+import type { ApiLogEntry } from '../logs/models/api-log.model';
+import { DashboardEmptyStateComponent } from '../main-dashboard/components/dashboard-empty-state/dashboard-empty-state.component';
+import { MainDashboardDataComponent } from '../main-dashboard/components/main-dashboard-data/main-dashboard-data.component';
+import { MainDashboardSidebarComponent } from '../main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component';
+import { MainDashboardUtilitySidebarComponent } from '../main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component';
+import { ProjectsRepository } from '../main-dashboard/data-access/projects.repository';
 import type { DashboardProject } from '../main-dashboard/models/dashboard-project.model';
 import type { CreateProjectAiFlowState, SidebarProjectRow, WorkspaceNavId } from './models/workspace-shell.model';
-import type { ApiLogEntry } from '../logs/models/api-log.model';
-import type { EndpointPreview } from '../../shared/models/endpoint-preview.model';
-import { ProjectsRepository } from '../main-dashboard/data-access/projects.repository';
-import { EndpointsRepository } from '../endpoints/data-access/endpoints.repository';
 
 @Component({
   selector: 'app-workspace-shell',

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.integration.spec.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.integration.spec.ts
@@ -129,7 +129,7 @@ describe('WorkspaceShellComponent integration', () => {
         name: 'Generated project',
         slug: 'generated-project',
         description: 'AI assisted workspace',
-        mockUrl: 'http://localhost:3000/mock/generated-project',
+        mockUrl: 'https://mock.example.com/generated-project',
         updatedAt: new Date().toISOString(),
         status: hasEndpoint ? 'running' : 'empty',
       },
@@ -213,7 +213,7 @@ describe('WorkspaceShellComponent integration', () => {
             name: 'Workspace project',
             slug: 'workspace-project',
             description: 'Live backend project',
-            mockUrl: 'http://localhost:3000/mock/workspace-project',
+            mockUrl: 'https://mock.example.com/workspace-project',
             updatedAt: new Date().toISOString(),
             status: 'running',
           },
@@ -301,7 +301,7 @@ describe('WorkspaceShellComponent integration', () => {
     expect(api.get).toHaveBeenCalledWith('/projects/p1/dashboard-summary');
     expect(content).toContain('Workspace project');
     expect(content).toContain('Live backend project');
-    expect(content).toContain('http://localhost:3000/mock/workspace-project');
+    expect(content).toContain('https://mock.example.com/workspace-project');
     expect(content).toContain('1 endpoints');
     expect(content).toContain('/users');
   });

--- a/apps/web/src/app/shared/config/api.config.ts
+++ b/apps/web/src/app/shared/config/api.config.ts
@@ -1,9 +1,8 @@
 import { InjectionToken, makeEnvironmentProviders, type EnvironmentProviders } from '@angular/core';
+import { getAppRuntimeConfig } from './app-runtime-config';
 
 export const API_BASE_URL = new InjectionToken<string>('API_BASE_URL');
 
-const DEFAULT_API_BASE_URL = 'http://localhost:3000/api/v1';
-
-export function provideApiConfig(baseUrl = DEFAULT_API_BASE_URL): EnvironmentProviders {
+export function provideApiConfig(baseUrl = getAppRuntimeConfig().apiBaseUrl): EnvironmentProviders {
   return makeEnvironmentProviders([{ provide: API_BASE_URL, useValue: baseUrl.replace(/\/$/, '') }]);
 }

--- a/apps/web/src/app/shared/config/app-runtime-config.spec.ts
+++ b/apps/web/src/app/shared/config/app-runtime-config.spec.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { DEFAULT_API_BASE_URL, DEFAULT_MOCK_BASE_URL, getAppRuntimeConfig } from './app-runtime-config';
+
+type RuntimeConfigGlobal = typeof globalThis & {
+  __SIMULADOR_RUNTIME_CONFIG__?: {
+    apiBaseUrl?: string;
+    mockBaseUrl?: string;
+  };
+};
+
+const runtimeConfigGlobal = globalThis as RuntimeConfigGlobal;
+
+describe('app-runtime-config', () => {
+  afterEach(() => {
+    delete runtimeConfigGlobal.__SIMULADOR_RUNTIME_CONFIG__;
+  });
+
+  it('keeps the localhost defaults when no runtime overrides are present', () => {
+    expect(getAppRuntimeConfig()).toEqual({
+      apiBaseUrl: DEFAULT_API_BASE_URL,
+      mockBaseUrl: DEFAULT_MOCK_BASE_URL,
+    });
+  });
+
+  it('resolves both URLs from runtime overrides', () => {
+    runtimeConfigGlobal.__SIMULADOR_RUNTIME_CONFIG__ = {
+      apiBaseUrl: 'https://api.example.com/api/v1/',
+      mockBaseUrl: 'https://mock.example.com/base/',
+    };
+
+    expect(getAppRuntimeConfig()).toEqual({
+      apiBaseUrl: 'https://api.example.com/api/v1',
+      mockBaseUrl: 'https://mock.example.com/base',
+    });
+  });
+
+  it('derives the mock base from the configured API base when only one override is provided', () => {
+    runtimeConfigGlobal.__SIMULADOR_RUNTIME_CONFIG__ = {
+      apiBaseUrl: 'https://deploy.example.com/backend/api/v1/',
+    };
+
+    expect(getAppRuntimeConfig()).toEqual({
+      apiBaseUrl: 'https://deploy.example.com/backend/api/v1',
+      mockBaseUrl: 'https://deploy.example.com/backend/mock',
+    });
+  });
+});

--- a/apps/web/src/app/shared/config/app-runtime-config.ts
+++ b/apps/web/src/app/shared/config/app-runtime-config.ts
@@ -1,0 +1,55 @@
+export interface AppRuntimeConfig {
+  apiBaseUrl?: string;
+  mockBaseUrl?: string;
+}
+
+export interface ResolvedAppRuntimeConfig {
+  apiBaseUrl: string;
+  mockBaseUrl: string;
+}
+
+type RuntimeConfigGlobal = typeof globalThis & {
+  __SIMULADOR_RUNTIME_CONFIG__?: AppRuntimeConfig;
+};
+
+export const DEFAULT_API_BASE_URL = 'http://localhost:3000/api/v1';
+export const DEFAULT_MOCK_BASE_URL = 'http://localhost:3000/mock';
+
+const API_BASE_PATH_SUFFIX = '/api/v1';
+
+function normalizeBaseUrl(value?: string): string | undefined {
+  const normalized = value?.trim();
+  if (!normalized) return undefined;
+  return normalized.replace(/\/+$/, '');
+}
+
+function readRuntimeConfig(): AppRuntimeConfig {
+  return (globalThis as RuntimeConfigGlobal).__SIMULADOR_RUNTIME_CONFIG__ ?? {};
+}
+
+function deriveMockBaseUrl(apiBaseUrl: string): string {
+  try {
+    const url = new URL(apiBaseUrl);
+    const normalizedPath = url.pathname.replace(/\/+$/, '');
+
+    url.pathname = normalizedPath.endsWith(API_BASE_PATH_SUFFIX)
+      ? `${normalizedPath.slice(0, -API_BASE_PATH_SUFFIX.length) || ''}/mock`
+      : `${normalizedPath}/mock`;
+
+    return url.toString().replace(/\/$/, '');
+  } catch {
+    return DEFAULT_MOCK_BASE_URL;
+  }
+}
+
+export function getAppRuntimeConfig(overrides: AppRuntimeConfig = {}): ResolvedAppRuntimeConfig {
+  const runtimeConfig = { ...readRuntimeConfig(), ...overrides };
+  const apiBaseUrl = normalizeBaseUrl(runtimeConfig.apiBaseUrl) ?? DEFAULT_API_BASE_URL;
+  const mockBaseUrl = normalizeBaseUrl(runtimeConfig.mockBaseUrl) ?? deriveMockBaseUrl(apiBaseUrl);
+
+  return { apiBaseUrl, mockBaseUrl };
+}
+
+export function getMockBaseUrl(overrides: AppRuntimeConfig = {}): string {
+  return getAppRuntimeConfig(overrides).mockBaseUrl;
+}

--- a/apps/web/src/app/shared/ui/labeled-range/labeled-range.component.css
+++ b/apps/web/src/app/shared/ui/labeled-range/labeled-range.component.css
@@ -22,3 +22,8 @@
   accent-color: var(--cp-accent-primary);
   height: 0.35rem;
 }
+
+.cp-labeled-range__input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/apps/web/src/app/shared/ui/labeled-range/labeled-range.component.html
+++ b/apps/web/src/app/shared/ui/labeled-range/labeled-range.component.html
@@ -11,6 +11,7 @@
     [max]="max()"
     [step]="step()"
     [value]="value()"
+    [disabled]="disabled()"
     (input)="onInput($event)"
   />
 </div>

--- a/apps/web/src/app/shared/ui/labeled-range/labeled-range.component.ts
+++ b/apps/web/src/app/shared/ui/labeled-range/labeled-range.component.ts
@@ -16,6 +16,7 @@ export class LabeledRangeComponent {
   readonly max = input(100);
   readonly step = input(1);
   readonly inputId = input<string | null>(null);
+  readonly disabled = input(false);
 
   readonly valueChange = output<number>();
 

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -6,6 +6,7 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <script src="app-config.js"></script>
   </head>
   <body>
     <app-shell></app-shell>


### PR DESCRIPTION
Closes #22

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- make frontend API/mock URLs runtime-configurable so non-local deployments no longer depend on localhost defaults baked into the Angular source
- align unsupported mock-runtime knobs with real MVP behavior by canonicalizing backend values and keeping frontend controls visible but disabled with Próximamente
- refresh AI/docs wording so the product and documentation describe the real i-preview and i-generate flows without stale fallback promises

## Changes
| File | Change |
|------|--------|
| pps/web/public/app-config.js | adds runtime-overridable frontend API/mock configuration |
| pps/web/src/app/shared/config/* | resolves frontend runtime config instead of hardcoded localhost URLs |
| pps/web/src/app/features/main-dashboard/* | derives mock URLs from runtime config and updates related tests |
| pps/backend/src/management/{global-config,endpoint-config}/service.ts | canonicalizes unsupported MVP knobs to enforced backend values |
| pps/backend/src/mock-server/{latency.ts,mock.router.ts} | applies global latency project-wide in line with canonical MVP behavior |
| pps/web/src/app/features/global-config/* | keeps unsupported scope control visible but disabled with Próximamente copy |
| pps/web/src/app/features/endpoints/* | zeroes unsupported endpoint error rate, keeps UI visible-but-disabled, and aligns AI preview copy |
| README.md, pps/backend/README.md, pps/web/README.md | updates onboarding/runtime/AI docs to match the real MVP |

## Test Plan
- [x] Ran targeted backend integration coverage for canonicalization/runtime behavior
- [x] Ran targeted frontend specs for runtime config, dashboard mapping, unsupported controls, and AI preview wording
- [x] Pre-commit hooks ran successfully (prettier --write, eslint --fix)
- [x] No shell scripts were modified

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one 	ype:* label
- [x] Ran shellcheck on modified scripts (not applicable, no scripts changed)
- [x] Skills tested in at least one agent (not applicable, no skill changes)
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No Co-Authored-By trailers