### PR TITLE
feat(versioning): add project snapshots and restore flow

### DIFF
--- a/apps/backend/prisma/migrations/20260417111000_project_snapshots/migration.sql
+++ b/apps/backend/prisma/migrations/20260417111000_project_snapshots/migration.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "ProjectSnapshot" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "createdByUserId" TEXT NOT NULL,
+    "createdByEmail" TEXT,
+    "createdByDisplayName" TEXT,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ProjectSnapshot_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ProjectSnapshot_projectId_createdAt_id_idx"
+ON "ProjectSnapshot"("projectId", "createdAt" DESC, "id" DESC);
+
+ALTER TABLE "ProjectSnapshot"
+ADD CONSTRAINT "ProjectSnapshot_projectId_fkey"
+FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -20,6 +20,7 @@ model Project {
   globalConfig     GlobalConfig?
   logs             ApiLog[]
   auditEvents      AuditEvent[]
+  snapshots        ProjectSnapshot[]
   rateLimitBuckets RuntimeRateLimitBucket[]
 
   @@index([workspaceId])
@@ -191,6 +192,22 @@ model AuditEvent {
   @@index([projectId, createdAt(sort: Desc), id(sort: Desc)])
   @@index([projectId, resourceType, createdAt(sort: Desc), id(sort: Desc)])
   @@index([projectId, action, createdAt(sort: Desc), id(sort: Desc)])
+}
+
+model ProjectSnapshot {
+  id                   String   @id @default(cuid())
+  projectId            String
+  name                 String
+  description          String   @default("")
+  createdByUserId      String
+  createdByEmail       String?
+  createdByDisplayName String?
+  payload              Json
+  createdAt            DateTime @default(now())
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+
+  @@index([projectId, createdAt(sort: Desc), id(sort: Desc)])
 }
 
 model RuntimeRateLimitBucket {

--- a/apps/backend/src/__tests__/project-snapshots.integration.test.ts
+++ b/apps/backend/src/__tests__/project-snapshots.integration.test.ts
@@ -1,0 +1,899 @@
+import request from 'supertest';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Express } from 'express';
+
+const prismaMock = {
+  user: {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  workspace: {
+    create: vi.fn(),
+  },
+  workspaceMembership: {
+    create: vi.fn(),
+  },
+  externalIdentity: {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  project: {
+    findUnique: vi.fn(),
+  },
+  projectSnapshot: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    create: vi.fn(),
+  },
+  globalConfig: {
+    upsert: vi.fn(),
+  },
+  endpoint: {
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  endpointConfig: {
+    upsert: vi.fn(),
+  },
+  scenario: {
+    deleteMany: vi.fn(),
+    createMany: vi.fn(),
+  },
+  auditEvent: {
+    create: vi.fn(),
+  },
+  $transaction: vi.fn(),
+};
+
+vi.mock('../lib/prisma.js', () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock('openai', () => ({
+  default: class MockOpenAI {},
+}));
+
+let app: Express;
+
+function authHeaders(overrides: Record<string, string> = {}) {
+  return {
+    'x-clerk-auth-status': 'signed-in',
+    'x-clerk-user-id': 'user_clerk_123',
+    'x-clerk-email': 'owner@example.com',
+    'x-clerk-email-verified': 'true',
+    'x-clerk-display-name': 'Owner User',
+    ...overrides,
+  };
+}
+
+function buildActorIdentity(role: 'owner' | 'editor' | 'viewer' = 'owner') {
+  return {
+    provider: 'clerk',
+    subject: 'user_clerk_123',
+    email: 'owner@example.com',
+    emailVerified: true,
+    displayName: 'Owner User',
+    userId: 'user-1',
+    user: {
+      id: 'user-1',
+      email: 'owner@example.com',
+      displayName: 'Owner User',
+      memberships: [{ workspaceId: 'workspace-1', role }],
+      personalWorkspace: { id: 'workspace-1' },
+    },
+  };
+}
+
+function buildActorIdentityForWorkspace(
+  workspaceMemberships: Array<{ workspaceId: string; role: 'owner' | 'editor' | 'viewer' }>,
+  personalWorkspaceId = workspaceMemberships[0]?.workspaceId ?? null
+) {
+  return {
+    provider: 'clerk',
+    subject: 'user_clerk_123',
+    email: 'owner@example.com',
+    emailVerified: true,
+    displayName: 'Owner User',
+    userId: 'user-1',
+    user: {
+      id: 'user-1',
+      email: 'owner@example.com',
+      displayName: 'Owner User',
+      memberships: workspaceMemberships,
+      personalWorkspace: personalWorkspaceId ? { id: personalWorkspaceId } : null,
+    },
+  };
+}
+
+describe('project snapshots integration', () => {
+  beforeAll(async () => {
+    process.env.DATABASE_URL ??= 'postgresql://user:password@localhost:5432/simulador_api_ia_test';
+    process.env.OPENAI_MODEL ??= 'gpt-4.1-mini';
+
+    ({ app } = await import('../app.js'));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.externalIdentity.findUnique.mockResolvedValue(buildActorIdentity());
+    prismaMock.project.findUnique.mockImplementation(
+      async ({ where }: { where: { id: string } }) => ({
+        id: where.id,
+        workspaceId: 'workspace-1',
+      })
+    );
+    prismaMock.user.findUnique.mockResolvedValue({
+      email: 'owner@example.com',
+      displayName: 'Owner User',
+    });
+  });
+
+  it('creates a project snapshot and emits exactly one explicit snapshot audit event', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({
+      id: 'project-1',
+      workspaceId: 'workspace-1',
+      slug: 'users-api',
+      name: 'Users API',
+      description: 'Demo project',
+      globalConfig: null,
+      endpoints: [],
+    });
+
+    const tx = {
+      projectSnapshot: {
+        create: vi.fn(async () => ({
+          id: 'snapshot-1',
+          projectId: 'project-1',
+          name: 'Before edits',
+          description: 'Safe restore point',
+          createdByUserId: 'user-1',
+          createdByEmail: 'owner@example.com',
+          createdByDisplayName: 'Owner User',
+          payload: { project: { id: 'project-1' }, globalConfig: {}, endpoints: [] },
+          createdAt: new Date('2026-04-17T10:00:00.000Z'),
+        })),
+      },
+      project: {
+        findUniqueOrThrow: vi.fn(async () => ({
+          id: 'project-1',
+          workspaceId: 'workspace-1',
+          slug: 'users-api',
+          name: 'Users API',
+          description: 'Demo project',
+          globalConfig: null,
+          endpoints: [],
+        })),
+      },
+      user: prismaMock.user,
+      auditEvent: {
+        create: vi.fn(async () => ({ id: 'audit-1' })),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx)
+    );
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-1/snapshots')
+      .set(authHeaders())
+      .send({ name: 'Before edits', description: 'Safe restore point' });
+
+    expect(response.status).toBe(201);
+    expect(tx.projectSnapshot.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          createdByUserId: 'user-1',
+          createdByEmail: 'owner@example.com',
+          createdByDisplayName: 'Owner User',
+        }),
+      })
+    );
+    expect(tx.auditEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.auditEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          resourceType: 'snapshot',
+          resourceId: 'snapshot-1',
+          action: 'created',
+          summary: 'Created snapshot Before edits',
+        }),
+      })
+    );
+  });
+
+  it('returns an empty snapshot history when the project has no saved snapshots', async () => {
+    prismaMock.projectSnapshot.findMany.mockResolvedValue([]);
+
+    const response = await request(app)
+      .get('/api/v1/projects/project-1/snapshots')
+      .set(authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ items: [] });
+  });
+
+  it('lists only the requested project snapshots newest-first', async () => {
+    const snapshotRows = [
+      {
+        id: 'snapshot-older',
+        projectId: 'project-1',
+        name: 'Older snapshot',
+        description: '',
+        createdByUserId: 'user-1',
+        createdByEmail: 'owner@example.com',
+        createdByDisplayName: 'Owner User',
+        createdAt: new Date('2026-04-17T09:00:00.000Z'),
+      },
+      {
+        id: 'snapshot-foreign',
+        projectId: 'project-2',
+        name: 'Foreign snapshot',
+        description: '',
+        createdByUserId: 'user-2',
+        createdByEmail: 'other@example.com',
+        createdByDisplayName: 'Other User',
+        createdAt: new Date('2026-04-17T11:00:00.000Z'),
+      },
+      {
+        id: 'snapshot-newest',
+        projectId: 'project-1',
+        name: 'Newest snapshot',
+        description: '',
+        createdByUserId: 'user-1',
+        createdByEmail: 'owner@example.com',
+        createdByDisplayName: 'Owner User',
+        createdAt: new Date('2026-04-17T10:00:00.000Z'),
+      },
+    ];
+
+    prismaMock.projectSnapshot.findMany.mockImplementation(
+      async ({
+        where,
+        orderBy,
+      }: {
+        where: { projectId: string };
+        orderBy: Array<Record<string, 'asc' | 'desc'>>;
+      }) =>
+        snapshotRows
+          .filter((snapshot) => snapshot.projectId === where.projectId)
+          .sort((left, right) => {
+            const createdAtDelta = right.createdAt.getTime() - left.createdAt.getTime();
+            if (createdAtDelta !== 0) return createdAtDelta;
+            return right.id.localeCompare(left.id);
+          })
+          .filter(() =>
+            orderBy.some((entry) =>
+              Object.entries(entry).some(
+                ([key, value]) => (key === 'createdAt' || key === 'id') && value === 'desc'
+              )
+            )
+          )
+    );
+
+    const response = await request(app)
+      .get('/api/v1/projects/project-1/snapshots')
+      .set(authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body.items.map((item: { id: string }) => item.id)).toEqual([
+      'snapshot-newest',
+      'snapshot-older',
+    ]);
+    expect(
+      response.body.items.every((item: { projectId: string }) => item.projectId === 'project-1')
+    ).toBe(true);
+    expect(prismaMock.projectSnapshot.findMany).toHaveBeenCalledWith({
+      where: { projectId: 'project-1' },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    });
+  });
+
+  it('returns snapshot detail for readers with immutable creator metadata', async () => {
+    prismaMock.projectSnapshot.findFirst.mockResolvedValue({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before edits',
+      description: 'Safe restore point',
+      createdByUserId: 'user-1',
+      createdByEmail: 'owner@example.com',
+      createdByDisplayName: 'Owner User',
+      payload: {
+        project: {
+          id: 'project-1',
+          slug: 'users-api',
+          name: 'Users API',
+          description: 'Demo project',
+        },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: false,
+          latencyMinMs: 0,
+          latencyMaxMs: 1000,
+          latencyMode: 'fixed',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 60,
+          loggingLevel: 'basic',
+          scope: 'all',
+        },
+        endpoints: [],
+      },
+      createdAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    const response = await request(app)
+      .get('/api/v1/projects/project-1/snapshots/snapshot-1')
+      .set(authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before edits',
+      createdBy: {
+        userId: 'user-1',
+        email: 'owner@example.com',
+        displayName: 'Owner User',
+      },
+      payload: {
+        project: { id: 'project-1', slug: 'users-api', name: 'Users API' },
+        endpoints: [],
+      },
+    });
+  });
+
+  it('rejects reading snapshot detail through a different project id', async () => {
+    prismaMock.projectSnapshot.findFirst.mockImplementation(
+      async ({ where }: { where: { id: string; projectId: string } }) =>
+        where.projectId === 'project-2'
+          ? null
+          : {
+              id: where.id,
+              projectId: 'project-1',
+              name: 'Before edits',
+              description: 'Safe restore point',
+              createdByUserId: 'user-1',
+              createdByEmail: 'owner@example.com',
+              createdByDisplayName: 'Owner User',
+              payload: { project: { id: 'project-1' }, globalConfig: {}, endpoints: [] },
+              createdAt: new Date('2026-04-17T10:00:00.000Z'),
+            }
+    );
+
+    const response = await request(app)
+      .get('/api/v1/projects/project-2/snapshots/snapshot-1')
+      .set(authHeaders());
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'Snapshot not found' });
+  });
+
+  it('allows viewers to read snapshot history but blocks snapshot creation', async () => {
+    prismaMock.externalIdentity.findUnique.mockResolvedValue(buildActorIdentity('viewer'));
+    prismaMock.projectSnapshot.findMany.mockResolvedValue([
+      {
+        id: 'snapshot-1',
+        projectId: 'project-1',
+        name: 'Before edits',
+        description: 'Safe restore point',
+        createdByUserId: 'user-1',
+        createdByEmail: 'owner@example.com',
+        createdByDisplayName: 'Owner User',
+        createdAt: new Date('2026-04-17T10:00:00.000Z'),
+      },
+    ]);
+
+    const listResponse = await request(app)
+      .get('/api/v1/projects/project-1/snapshots')
+      .set(authHeaders());
+    const createResponse = await request(app)
+      .post('/api/v1/projects/project-1/snapshots')
+      .set(authHeaders())
+      .send({ name: 'Blocked snapshot' });
+    const restoreResponse = await request(app)
+      .post('/api/v1/projects/project-1/snapshots/snapshot-1/restore')
+      .set(authHeaders())
+      .send({});
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.items).toHaveLength(1);
+    expect(createResponse.status).toBe(403);
+    expect(restoreResponse.status).toBe(403);
+    expect(prismaMock.auditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('blocks snapshot mutations for non-members without writing audit events', async () => {
+    prismaMock.externalIdentity.findUnique.mockResolvedValue(
+      buildActorIdentityForWorkspace([{ workspaceId: 'workspace-2', role: 'editor' }])
+    );
+
+    const createResponse = await request(app)
+      .post('/api/v1/projects/project-1/snapshots')
+      .set(authHeaders())
+      .send({ name: 'Blocked snapshot' });
+    const restoreResponse = await request(app)
+      .post('/api/v1/projects/project-1/snapshots/snapshot-1/restore')
+      .set(authHeaders())
+      .send({});
+
+    expect(createResponse.status).toBe(403);
+    expect(createResponse.body).toEqual({
+      error: 'You do not have access to this workspace',
+      code: 'WORKSPACE_ACCESS_DENIED',
+    });
+    expect(restoreResponse.status).toBe(403);
+    expect(restoreResponse.body).toEqual({
+      error: 'You do not have access to this workspace',
+      code: 'WORKSPACE_ACCESS_DENIED',
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    expect(prismaMock.auditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('blocks snapshot list and detail reads for non-members', async () => {
+    prismaMock.externalIdentity.findUnique.mockResolvedValue(
+      buildActorIdentityForWorkspace([{ workspaceId: 'workspace-2', role: 'viewer' }])
+    );
+
+    const listResponse = await request(app)
+      .get('/api/v1/projects/project-1/snapshots')
+      .set(authHeaders());
+    const detailResponse = await request(app)
+      .get('/api/v1/projects/project-1/snapshots/snapshot-1')
+      .set(authHeaders());
+
+    expect(listResponse.status).toBe(403);
+    expect(listResponse.body).toEqual({
+      error: 'You do not have access to this workspace',
+      code: 'WORKSPACE_ACCESS_DENIED',
+    });
+    expect(detailResponse.status).toBe(403);
+    expect(detailResponse.body).toEqual({
+      error: 'You do not have access to this workspace',
+      code: 'WORKSPACE_ACCESS_DENIED',
+    });
+    expect(prismaMock.projectSnapshot.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.projectSnapshot.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('restores a snapshot through one transaction and emits a single restore audit event', async () => {
+    prismaMock.projectSnapshot.findFirst.mockResolvedValue({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before imports',
+      description: '',
+      createdByUserId: 'user-1',
+      createdByEmail: 'owner@example.com',
+      createdByDisplayName: 'Owner User',
+      payload: {
+        project: { id: 'project-1', slug: 'users-api', name: 'Users API', description: 'Baseline' },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: false,
+          latencyMinMs: 0,
+          latencyMaxMs: 1000,
+          latencyMode: 'fixed',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 60,
+          loggingLevel: 'basic',
+          scope: 'all',
+        },
+        endpoints: [
+          {
+            method: 'GET',
+            path: '/users',
+            description: 'List users',
+            statusCode: 200,
+            responseBody: [{ id: 1 }],
+            endpointConfig: {
+              latencyMode: 'fixed',
+              fixedDelayMs: 0,
+              minDelayMs: 0,
+              maxDelayMs: 500,
+              errorRate: 0,
+              useScenarioWeights: true,
+            },
+            scenarios: [
+              {
+                name: 'ok',
+                type: 'success',
+                statusCode: 200,
+                body: [{ id: 1 }],
+                delayMs: 0,
+                weight: 1,
+              },
+            ],
+          },
+        ],
+      },
+      createdAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    const tx = {
+      project: {
+        update: vi.fn(async () => ({ id: 'project-1', workspaceId: 'workspace-1' })),
+      },
+      globalConfig: {
+        upsert: vi.fn(async () => ({ projectId: 'project-1' })),
+      },
+      endpoint: {
+        findMany: vi.fn(async () => [{ id: 'endpoint-old', method: 'DELETE', path: '/users/:id' }]),
+        create: vi.fn(async () => ({ id: 'endpoint-1' })),
+        update: vi.fn(),
+        deleteMany: vi.fn(async () => ({ count: 1 })),
+      },
+      endpointConfig: {
+        upsert: vi.fn(async () => ({ endpointId: 'endpoint-1' })),
+      },
+      scenario: {
+        deleteMany: vi.fn(async () => ({ count: 0 })),
+        createMany: vi.fn(async () => ({ count: 1 })),
+      },
+      user: prismaMock.user,
+      auditEvent: {
+        create: vi.fn(async () => ({ id: 'audit-restore' })),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx)
+    );
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-1/snapshots/snapshot-1/restore')
+      .set(authHeaders())
+      .send({});
+
+    expect(response.status).toBe(200);
+    expect(tx.endpoint.deleteMany).toHaveBeenCalledWith({
+      where: { id: { in: ['endpoint-old'] } },
+    });
+    expect(tx.auditEvent.create).toHaveBeenCalledTimes(1);
+    expect(tx.auditEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          resourceType: 'snapshot',
+          resourceId: 'snapshot-1',
+          action: 'restored',
+          summary: 'Restored snapshot Before imports',
+        }),
+      })
+    );
+  });
+
+  it('returns 401 without writing an audit event when the request is unauthenticated', async () => {
+    const response = await request(app)
+      .post('/api/v1/projects/project-1/snapshots')
+      .send({ name: 'Blocked snapshot' });
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ error: 'Authentication required', code: 'AUTH_REQUIRED' });
+    expect(prismaMock.auditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('fails restore atomically and skips restore audit writes when reconciliation throws', async () => {
+    prismaMock.projectSnapshot.findFirst.mockResolvedValue({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before imports',
+      description: '',
+      createdByUserId: 'user-1',
+      createdByEmail: 'owner@example.com',
+      createdByDisplayName: 'Owner User',
+      payload: {
+        project: { id: 'project-1', slug: 'users-api', name: 'Users API', description: 'Baseline' },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: false,
+          latencyMinMs: 0,
+          latencyMaxMs: 1000,
+          latencyMode: 'fixed',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 60,
+          loggingLevel: 'basic',
+          scope: 'all',
+        },
+        endpoints: [
+          {
+            method: 'GET',
+            path: '/users',
+            description: 'List users',
+            statusCode: 200,
+            responseBody: [{ id: 1 }],
+            endpointConfig: {
+              latencyMode: 'fixed',
+              fixedDelayMs: 0,
+              minDelayMs: 0,
+              maxDelayMs: 500,
+              errorRate: 0,
+              useScenarioWeights: true,
+            },
+            scenarios: [],
+          },
+        ],
+      },
+      createdAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    const tx = {
+      project: {
+        update: vi.fn(async () => ({ id: 'project-1', workspaceId: 'workspace-1' })),
+      },
+      globalConfig: {
+        upsert: vi.fn(async () => ({ projectId: 'project-1' })),
+      },
+      endpoint: {
+        findMany: vi.fn(async () => []),
+        create: vi.fn(async () => {
+          throw new Error('restore failed');
+        }),
+        update: vi.fn(),
+        deleteMany: vi.fn(async () => ({ count: 0 })),
+      },
+      endpointConfig: {
+        upsert: vi.fn(async () => ({ endpointId: 'endpoint-1' })),
+      },
+      scenario: {
+        deleteMany: vi.fn(async () => ({ count: 0 })),
+        createMany: vi.fn(async () => ({ count: 0 })),
+      },
+      user: prismaMock.user,
+      auditEvent: {
+        create: vi.fn(async () => ({ id: 'audit-restore' })),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx)
+    );
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-1/snapshots/snapshot-1/restore')
+      .set(authHeaders())
+      .send({});
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+    expect(tx.auditEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('keeps the live project state unchanged when a transactional restore write fails mid-flight', async () => {
+    const liveState: {
+      project: {
+        id: string;
+        workspaceId: string;
+        slug: string;
+        name: string;
+        description: string;
+      };
+      globalConfig: {
+        projectId: string;
+        latencyEnabled: boolean;
+        latencyMinMs: number;
+        latencyMaxMs: number;
+        latencyMode: string;
+        errorSimulationEnabled: boolean;
+        errorSimulationRate: number;
+        errorSimulationCodes: number[];
+        rateLimitingEnabled: boolean;
+        rateLimitingRpm: number;
+        loggingLevel: string;
+        scope: string;
+      };
+      endpoints: Array<{
+        id: string;
+        projectId: string;
+        method: string;
+        path: string;
+        description: string;
+        statusCode: number;
+        responseBody: unknown;
+      }>;
+      auditEvents: Array<{ id: string }>;
+    } = {
+      project: {
+        id: 'project-1',
+        workspaceId: 'workspace-1',
+        slug: 'users-api',
+        name: 'Live Users API',
+        description: 'Live description',
+      },
+      globalConfig: {
+        projectId: 'project-1',
+        latencyEnabled: false,
+        latencyMinMs: 0,
+        latencyMaxMs: 1000,
+        latencyMode: 'fixed',
+        errorSimulationEnabled: false,
+        errorSimulationRate: 0,
+        errorSimulationCodes: [500],
+        rateLimitingEnabled: false,
+        rateLimitingRpm: 60,
+        loggingLevel: 'basic',
+        scope: 'all',
+      },
+      endpoints: [
+        {
+          id: 'endpoint-live',
+          projectId: 'project-1',
+          method: 'DELETE',
+          path: '/users/:id',
+          description: 'Delete user',
+          statusCode: 204,
+          responseBody: null,
+        },
+      ],
+      auditEvents: [] as Array<{ id: string }>,
+    };
+
+    prismaMock.project.findUnique.mockImplementation(
+      async ({ where }: { where: { id: string } }) => {
+        if (where.id !== liveState.project.id) return null;
+        return { id: liveState.project.id, workspaceId: liveState.project.workspaceId };
+      }
+    );
+    prismaMock.projectSnapshot.findFirst.mockResolvedValue({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before imports',
+      description: '',
+      createdByUserId: 'user-1',
+      createdByEmail: 'owner@example.com',
+      createdByDisplayName: 'Owner User',
+      payload: {
+        project: {
+          id: 'project-1',
+          slug: 'users-api',
+          name: 'Snapshot Users API',
+          description: 'Snapshot description',
+        },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: true,
+          latencyMinMs: 10,
+          latencyMaxMs: 20,
+          latencyMode: 'range',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: true,
+          rateLimitingRpm: 90,
+          loggingLevel: 'full',
+          scope: 'all',
+        },
+        endpoints: [
+          {
+            method: 'GET',
+            path: '/users',
+            description: 'List users',
+            statusCode: 200,
+            responseBody: [{ id: 1 }],
+            endpointConfig: {
+              latencyMode: 'fixed',
+              fixedDelayMs: 0,
+              minDelayMs: 0,
+              maxDelayMs: 500,
+              errorRate: 0,
+              useScenarioWeights: true,
+            },
+            scenarios: [],
+          },
+        ],
+      },
+      createdAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (client: Record<string, unknown>) => Promise<unknown>) => {
+        const workingState = structuredClone(liveState);
+        const tx = {
+          project: {
+            update: vi.fn(async ({ data }: { data: { name: string; description: string } }) => {
+              workingState.project.name = data.name;
+              workingState.project.description = data.description;
+              return { ...workingState.project };
+            }),
+          },
+          globalConfig: {
+            upsert: vi.fn(async ({ update }: { update: typeof workingState.globalConfig }) => {
+              workingState.globalConfig = { ...update };
+              return workingState.globalConfig;
+            }),
+          },
+          endpoint: {
+            findMany: vi.fn(async () =>
+              workingState.endpoints.map(({ id, method, path }) => ({ id, method, path }))
+            ),
+            create: vi.fn(
+              async ({
+                data,
+              }: {
+                data: {
+                  projectId: string;
+                  method: string;
+                  path: string;
+                  description: string;
+                  statusCode: number;
+                  responseBody: unknown;
+                };
+              }) => {
+                const created = { id: 'endpoint-created', ...data };
+                workingState.endpoints.push(created);
+                return { id: created.id };
+              }
+            ),
+            update: vi.fn(),
+            deleteMany: vi.fn(async () => ({ count: 0 })),
+          },
+          endpointConfig: {
+            upsert: vi.fn(async () => {
+              throw new Error('restore failed after writes');
+            }),
+          },
+          scenario: {
+            deleteMany: vi.fn(async () => ({ count: 0 })),
+            createMany: vi.fn(async () => ({ count: 0 })),
+          },
+          auditEvent: {
+            create: vi.fn(async ({ data }: { data: { id?: string } }) => {
+              const event = { id: data.id ?? 'audit-restore' };
+              workingState.auditEvents.push(event);
+              return event;
+            }),
+          },
+        };
+
+        const result = await callback(tx);
+        liveState.project = workingState.project;
+        liveState.globalConfig = workingState.globalConfig;
+        liveState.endpoints = workingState.endpoints;
+        liveState.auditEvents = workingState.auditEvents;
+        return result;
+      }
+    );
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-1/snapshots/snapshot-1/restore')
+      .set(authHeaders())
+      .send({});
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+    expect(liveState.project).toMatchObject({
+      id: 'project-1',
+      name: 'Live Users API',
+      description: 'Live description',
+    });
+    expect(liveState.globalConfig).toMatchObject({
+      projectId: 'project-1',
+      latencyEnabled: false,
+      rateLimitingEnabled: false,
+      rateLimitingRpm: 60,
+    });
+    expect(liveState.endpoints).toEqual([
+      {
+        id: 'endpoint-live',
+        projectId: 'project-1',
+        method: 'DELETE',
+        path: '/users/:id',
+        description: 'Delete user',
+        statusCode: 204,
+        responseBody: null,
+      },
+    ]);
+    expect(liveState.auditEvents).toEqual([]);
+  });
+});

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -15,6 +15,7 @@ import { endpointsRouter } from './management/endpoints/router.js';
 import { globalConfigRouter } from './management/global-config/router.js';
 import { logsRouter } from './management/logs/router.js';
 import { projectsRouter } from './management/projects/router.js';
+import { projectSnapshotsRouter } from './management/project-snapshots/router.js';
 import { scenariosRouter } from './management/scenarios/router.js';
 import { opsRouter } from './management/ops/router.js';
 import { workspaceMembersRouter } from './management/workspace-members/router.js';
@@ -46,6 +47,7 @@ app.use('/api/v1/endpoints/:endpointId/config', endpointConfigRouter);
 app.use('/api/v1/projects/:projectId/config', globalConfigRouter);
 app.use('/api/v1/projects/:projectId/logs', logsRouter);
 app.use('/api/v1/projects/:projectId/audit-events', auditEventsRouter);
+app.use('/api/v1/projects/:projectId/snapshots', projectSnapshotsRouter);
 app.use('/api/v1/workspaces/:workspaceId/members', workspaceMembersRouter);
 app.use('/mock', mockRouter);
 

--- a/apps/backend/src/management/audit-events/schema.ts
+++ b/apps/backend/src/management/audit-events/schema.ts
@@ -13,8 +13,9 @@ export const auditEventResourceTypeSchema = z.enum([
   'scenario',
   'global-config',
   'endpoint-config',
+  'snapshot',
 ]);
-export const auditEventActionSchema = z.enum(['created', 'updated', 'deleted']);
+export const auditEventActionSchema = z.enum(['created', 'updated', 'deleted', 'restored']);
 
 export const projectParamsSchema = z.object({
   projectId: z.string().min(1),

--- a/apps/backend/src/management/project-snapshots/router.ts
+++ b/apps/backend/src/management/project-snapshots/router.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express';
+import { requireRequestActor } from '../../auth/request-context.js';
+import {
+  createProjectSnapshotSchema,
+  projectParamsSchema,
+  restoreProjectSnapshotSchema,
+  snapshotParamsSchema,
+} from './schema.js';
+import {
+  createProjectSnapshot,
+  getProjectSnapshotDetail,
+  listProjectSnapshots,
+  restoreProjectSnapshot,
+} from './service.js';
+
+export const projectSnapshotsRouter = Router({ mergeParams: true });
+
+projectSnapshotsRouter.get('/', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { projectId } = projectParamsSchema.parse(req.params);
+    res.status(200).json(await listProjectSnapshots(actor, projectId));
+  } catch (error) {
+    next(error);
+  }
+});
+
+projectSnapshotsRouter.post('/', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { projectId } = projectParamsSchema.parse(req.params);
+    const input = createProjectSnapshotSchema.parse(req.body);
+    res.status(201).json(await createProjectSnapshot(actor, projectId, input));
+  } catch (error) {
+    next(error);
+  }
+});
+
+projectSnapshotsRouter.get('/:snapshotId', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { projectId, snapshotId } = snapshotParamsSchema.parse(req.params);
+    res.status(200).json(await getProjectSnapshotDetail(actor, projectId, snapshotId));
+  } catch (error) {
+    next(error);
+  }
+});
+
+projectSnapshotsRouter.post('/:snapshotId/restore', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { projectId, snapshotId } = snapshotParamsSchema.parse(req.params);
+    restoreProjectSnapshotSchema.parse(req.body ?? {});
+    res.status(200).json(await restoreProjectSnapshot(actor, projectId, snapshotId));
+  } catch (error) {
+    next(error);
+  }
+});

--- a/apps/backend/src/management/project-snapshots/schema.ts
+++ b/apps/backend/src/management/project-snapshots/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const projectParamsSchema = z.object({
+  projectId: z.string().min(1),
+});
+
+export const snapshotParamsSchema = z.object({
+  projectId: z.string().min(1),
+  snapshotId: z.string().min(1),
+});
+
+export const createProjectSnapshotSchema = z.object({
+  name: z.string().trim().min(1).max(120),
+  description: z.string().trim().max(500).optional(),
+});
+
+export const restoreProjectSnapshotSchema = z.object({}).default({});
+
+export type CreateProjectSnapshotInput = z.infer<typeof createProjectSnapshotSchema>;

--- a/apps/backend/src/management/project-snapshots/service.test.ts
+++ b/apps/backend/src/management/project-snapshots/service.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSnapshotPayload,
+  buildSnapshotEndpointKey,
+  planSnapshotEndpointReconciliation,
+} from './service.js';
+
+describe('project-snapshots/service helpers', () => {
+  it('normalizes canonical project state into an immutable snapshot payload', () => {
+    const payload = buildSnapshotPayload({
+      id: 'project-1',
+      slug: 'users-api',
+      name: 'Users API',
+      description: 'Project snapshot',
+      globalConfig: null,
+      endpoints: [
+        {
+          method: 'post',
+          path: '/users',
+          description: 'Create user',
+          statusCode: 201,
+          responseBody: { ok: true },
+          endpointConfig: null,
+          scenarios: [
+            {
+              name: 'created',
+              type: 'success',
+              statusCode: 201,
+              body: { ok: true },
+              delayMs: 0,
+              weight: 1,
+            },
+          ],
+        },
+        {
+          method: 'get',
+          path: '/users',
+          description: '',
+          statusCode: 200,
+          responseBody: [{ id: 1 }],
+          endpointConfig: {
+            latencyMode: 'range',
+            fixedDelayMs: 0,
+            minDelayMs: 50,
+            maxDelayMs: 150,
+            errorRate: 0,
+            useScenarioWeights: true,
+          },
+          scenarios: [
+            {
+              name: 'ok',
+              type: 'success',
+              statusCode: 200,
+              body: [{ id: 1 }],
+              delayMs: 10,
+              weight: 2,
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(payload.project).toEqual({
+      id: 'project-1',
+      slug: 'users-api',
+      name: 'Users API',
+      description: 'Project snapshot',
+    });
+    expect(payload.globalConfig.projectId).toBe('project-1');
+    expect(payload.endpoints.map((endpoint) => `${endpoint.method} ${endpoint.path}`)).toEqual([
+      'GET /users',
+      'POST /users',
+    ]);
+    expect(payload.endpoints[0]?.endpointConfig).toEqual({
+      latencyMode: 'range',
+      fixedDelayMs: 0,
+      minDelayMs: 50,
+      maxDelayMs: 150,
+      errorRate: 0,
+      useScenarioWeights: true,
+    });
+    expect(payload.endpoints[1]?.endpointConfig).toEqual({
+      latencyMode: 'fixed',
+      fixedDelayMs: 0,
+      minDelayMs: 0,
+      maxDelayMs: 500,
+      errorRate: 0,
+      useScenarioWeights: true,
+    });
+  });
+
+  it('reconciles live endpoints against snapshot keys and marks absent live records for deletion', () => {
+    const plan = planSnapshotEndpointReconciliation(
+      [
+        { method: 'GET', path: '/users' },
+        { method: 'POST', path: '/users' },
+      ],
+      [
+        { id: 'live-1', method: 'GET', path: '/users' },
+        { id: 'live-2', method: 'DELETE', path: '/users/:id' },
+      ]
+    );
+
+    expect(plan.keep.map((entry) => entry.key)).toEqual(['GET /users']);
+    expect(plan.create.map((entry) => buildSnapshotEndpointKey(entry.method, entry.path))).toEqual([
+      'POST /users',
+    ]);
+    expect(plan.deleteIds).toEqual(['live-2']);
+  });
+
+  it('captures only canonical management state and omits out-of-scope runtime or membership data', () => {
+    const payload = buildSnapshotPayload({
+      id: 'project-1',
+      slug: 'users-api',
+      name: 'Users API',
+      description: 'Project snapshot',
+      globalConfig: {
+        latencyEnabled: true,
+        latencyMinMs: 25,
+        latencyMaxMs: 125,
+        latencyMode: 'range',
+        errorSimulationEnabled: false,
+        errorSimulationRate: 0,
+        errorSimulationCodes: [500],
+        rateLimitingEnabled: true,
+        rateLimitingRpm: 90,
+        loggingLevel: 'full',
+        scope: 'all',
+        authTokens: ['secret-token'],
+        runtimeLogs: [{ id: 'log-1' }],
+      } as never,
+      endpoints: [
+        {
+          method: 'get',
+          path: '/users',
+          description: 'List users',
+          statusCode: 200,
+          responseBody: [{ id: 1 }],
+          endpointConfig: {
+            latencyMode: 'fixed',
+            fixedDelayMs: 10,
+            minDelayMs: 10,
+            maxDelayMs: 10,
+            errorRate: 0,
+            useScenarioWeights: true,
+            runtimeState: { requests: 99 },
+          } as never,
+          scenarios: [
+            {
+              name: 'ok',
+              type: 'success',
+              statusCode: 200,
+              body: [{ id: 1 }],
+              delayMs: 0,
+              weight: 1,
+              authContext: { userId: 'viewer-1' },
+            } as never,
+          ],
+          workspaceMembers: [{ userId: 'viewer-1' }],
+        } as never,
+      ],
+      workspaceMembers: [{ userId: 'viewer-1', role: 'viewer' }],
+      runtimeLogs: [{ id: 'log-1' }],
+    } as never);
+
+    expect(payload).toEqual({
+      project: {
+        id: 'project-1',
+        slug: 'users-api',
+        name: 'Users API',
+        description: 'Project snapshot',
+      },
+      globalConfig: {
+        projectId: 'project-1',
+        latencyEnabled: true,
+        latencyMinMs: 25,
+        latencyMaxMs: 125,
+        latencyMode: 'range',
+        errorSimulationEnabled: false,
+        errorSimulationRate: 0,
+        errorSimulationCodes: [500],
+        rateLimitingEnabled: true,
+        rateLimitingRpm: 90,
+        loggingLevel: 'full',
+        scope: 'all',
+      },
+      endpoints: [
+        {
+          method: 'GET',
+          path: '/users',
+          description: 'List users',
+          statusCode: 200,
+          responseBody: [{ id: 1 }],
+          endpointConfig: {
+            latencyMode: 'fixed',
+            fixedDelayMs: 10,
+            minDelayMs: 10,
+            maxDelayMs: 10,
+            errorRate: 0,
+            useScenarioWeights: true,
+          },
+          scenarios: [
+            {
+              name: 'ok',
+              type: 'success',
+              statusCode: 200,
+              body: [{ id: 1 }],
+              delayMs: 0,
+              weight: 1,
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/apps/backend/src/management/project-snapshots/service.test.ts
+++ b/apps/backend/src/management/project-snapshots/service.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, it } from 'vitest';
-import {
-  buildSnapshotPayload,
-  buildSnapshotEndpointKey,
-  planSnapshotEndpointReconciliation,
-} from './service.js';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type * as ProjectSnapshotsService from './service.js';
+
+vi.mock('../../lib/prisma.js', () => ({
+  prisma: {
+    project: { findUnique: vi.fn() },
+    projectSnapshot: { findFirst: vi.fn(), findMany: vi.fn(), create: vi.fn() },
+    auditEvent: { findMany: vi.fn(), create: vi.fn() },
+    endpoint: { findUnique: vi.fn() },
+    $transaction: vi.fn(),
+  },
+}));
+
+let buildSnapshotPayload: typeof ProjectSnapshotsService.buildSnapshotPayload;
+let buildSnapshotEndpointKey: typeof ProjectSnapshotsService.buildSnapshotEndpointKey;
+let planSnapshotEndpointReconciliation: typeof ProjectSnapshotsService.planSnapshotEndpointReconciliation;
+
+beforeAll(async () => {
+  ({ buildSnapshotPayload, buildSnapshotEndpointKey, planSnapshotEndpointReconciliation } =
+    await import('./service.js'));
+});
 
 describe('project-snapshots/service helpers', () => {
   it('normalizes canonical project state into an immutable snapshot payload', () => {

--- a/apps/backend/src/management/project-snapshots/service.ts
+++ b/apps/backend/src/management/project-snapshots/service.ts
@@ -1,0 +1,544 @@
+import { authorizeProjectAccess } from '../../auth/authorization.js';
+import type { AuthenticatedActor } from '../../auth/types.js';
+import { prisma } from '../../lib/prisma.js';
+import { toPrismaJson } from '../../lib/prisma-json.js';
+import { AppError } from '../../middleware/error-handler.js';
+import { writeAuditEvent } from '../audit-events/service.js';
+import { buildDefaultGlobalConfig } from '../global-config/defaults.js';
+import type { UpsertGlobalConfigInput } from '../global-config/schema.js';
+import type { CreateProjectSnapshotInput } from './schema.js';
+
+interface SnapshotEndpointConfigPayload {
+  latencyMode: 'fixed' | 'range';
+  fixedDelayMs: number;
+  minDelayMs: number;
+  maxDelayMs: number;
+  errorRate: number;
+  useScenarioWeights: boolean;
+}
+
+interface SnapshotEndpointConfigSource {
+  latencyMode?: unknown;
+  fixedDelayMs?: unknown;
+  minDelayMs?: unknown;
+  maxDelayMs?: unknown;
+  errorRate?: unknown;
+  useScenarioWeights?: unknown;
+}
+
+interface SnapshotScenarioSource {
+  name: string;
+  type: unknown;
+  statusCode: number;
+  body: unknown;
+  delayMs: number;
+  weight: number;
+}
+
+interface SnapshotScenarioPayload {
+  name: string;
+  type: 'success' | 'error' | 'timeout' | 'empty';
+  statusCode: number;
+  body: unknown;
+  delayMs: number;
+  weight: number;
+}
+
+interface SnapshotEndpointPayload {
+  method: string;
+  path: string;
+  description: string;
+  statusCode: number;
+  responseBody: unknown;
+  endpointConfig: SnapshotEndpointConfigPayload;
+  scenarios: SnapshotScenarioPayload[];
+}
+
+type SnapshotGlobalConfigPayload = UpsertGlobalConfigInput & { projectId: string };
+
+export interface ProjectSnapshotPayload {
+  project: {
+    id: string;
+    slug: string;
+    name: string;
+    description: string;
+  };
+  globalConfig: SnapshotGlobalConfigPayload;
+  endpoints: SnapshotEndpointPayload[];
+}
+
+interface SnapshotGlobalConfigSource {
+  latencyEnabled?: unknown;
+  latencyMinMs?: unknown;
+  latencyMaxMs?: unknown;
+  latencyMode?: unknown;
+  errorSimulationEnabled?: unknown;
+  errorSimulationRate?: unknown;
+  errorSimulationCodes?: unknown;
+  rateLimitingEnabled?: unknown;
+  rateLimitingRpm?: unknown;
+  loggingLevel?: unknown;
+  scope?: unknown;
+}
+
+interface ProjectSnapshotSummary {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  createdBy: {
+    userId: string;
+    email: string | null;
+    displayName: string | null;
+  };
+}
+
+interface ProjectSnapshotDetail extends ProjectSnapshotSummary {
+  payload: ProjectSnapshotPayload;
+}
+
+interface ProjectSnapshotRecord {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string;
+  createdByUserId: string;
+  createdByEmail: string | null;
+  createdByDisplayName: string | null;
+  payload?: unknown;
+  createdAt: Date;
+}
+
+const DEFAULT_ENDPOINT_CONFIG: SnapshotEndpointConfigPayload = {
+  latencyMode: 'fixed',
+  fixedDelayMs: 0,
+  minDelayMs: 0,
+  maxDelayMs: 500,
+  errorRate: 0,
+  useScenarioWeights: true,
+};
+
+export function buildSnapshotEndpointKey(method: string, path: string): string {
+  return `${method.trim().toUpperCase()} ${path.trim()}`;
+}
+
+export function planSnapshotEndpointReconciliation(
+  snapshotEndpoints: Array<{ method: string; path: string }>,
+  liveEndpoints: Array<{ id: string; method: string; path: string }>
+) {
+  const snapshotByKey = new Map(
+    snapshotEndpoints.map((endpoint) => [
+      buildSnapshotEndpointKey(endpoint.method, endpoint.path),
+      endpoint,
+    ])
+  );
+  const liveByKey = new Map(
+    liveEndpoints.map((endpoint) => [
+      buildSnapshotEndpointKey(endpoint.method, endpoint.path),
+      endpoint,
+    ])
+  );
+
+  return {
+    keep: [...snapshotByKey.keys()]
+      .filter((key) => liveByKey.has(key))
+      .map((key) => ({ key, live: liveByKey.get(key)! })),
+    create: snapshotEndpoints.filter(
+      (endpoint) => !liveByKey.has(buildSnapshotEndpointKey(endpoint.method, endpoint.path))
+    ),
+    deleteIds: liveEndpoints
+      .filter(
+        (endpoint) => !snapshotByKey.has(buildSnapshotEndpointKey(endpoint.method, endpoint.path))
+      )
+      .map((endpoint) => endpoint.id),
+  };
+}
+
+function normalizeEndpointConfig(
+  config: SnapshotEndpointConfigSource | null | undefined
+): SnapshotEndpointConfigPayload {
+  return {
+    latencyMode: config?.latencyMode === 'range' ? 'range' : 'fixed',
+    fixedDelayMs:
+      typeof config?.fixedDelayMs === 'number'
+        ? config.fixedDelayMs
+        : DEFAULT_ENDPOINT_CONFIG.fixedDelayMs,
+    minDelayMs:
+      typeof config?.minDelayMs === 'number'
+        ? config.minDelayMs
+        : DEFAULT_ENDPOINT_CONFIG.minDelayMs,
+    maxDelayMs:
+      typeof config?.maxDelayMs === 'number'
+        ? config.maxDelayMs
+        : DEFAULT_ENDPOINT_CONFIG.maxDelayMs,
+    errorRate: 0,
+    useScenarioWeights:
+      typeof config?.useScenarioWeights === 'boolean'
+        ? config.useScenarioWeights
+        : DEFAULT_ENDPOINT_CONFIG.useScenarioWeights,
+  };
+}
+
+function toSnapshotSummary(snapshot: ProjectSnapshotRecord): ProjectSnapshotSummary {
+  return {
+    id: snapshot.id,
+    projectId: snapshot.projectId,
+    name: snapshot.name,
+    description: snapshot.description,
+    createdAt: snapshot.createdAt.toISOString(),
+    createdBy: {
+      userId: snapshot.createdByUserId,
+      email: snapshot.createdByEmail,
+      displayName: snapshot.createdByDisplayName,
+    },
+  };
+}
+
+function toSnapshotDetail(snapshot: ProjectSnapshotRecord): ProjectSnapshotDetail {
+  if (!snapshot.payload) {
+    throw new AppError(500, 'Snapshot payload is missing');
+  }
+
+  return {
+    ...toSnapshotSummary(snapshot),
+    payload: snapshot.payload as ProjectSnapshotPayload,
+  };
+}
+
+function normalizeSnapshotGlobalConfig(
+  projectId: string,
+  config: SnapshotGlobalConfigSource | null | undefined
+): SnapshotGlobalConfigPayload {
+  const defaults = buildDefaultGlobalConfig(projectId);
+
+  return {
+    projectId,
+    latencyEnabled:
+      typeof config?.latencyEnabled === 'boolean' ? config.latencyEnabled : defaults.latencyEnabled,
+    latencyMinMs:
+      typeof config?.latencyMinMs === 'number' ? config.latencyMinMs : defaults.latencyMinMs,
+    latencyMaxMs:
+      typeof config?.latencyMaxMs === 'number' ? config.latencyMaxMs : defaults.latencyMaxMs,
+    latencyMode: config?.latencyMode === 'range' ? 'range' : 'fixed',
+    errorSimulationEnabled:
+      typeof config?.errorSimulationEnabled === 'boolean'
+        ? config.errorSimulationEnabled
+        : defaults.errorSimulationEnabled,
+    errorSimulationRate:
+      typeof config?.errorSimulationRate === 'number'
+        ? config.errorSimulationRate
+        : defaults.errorSimulationRate,
+    errorSimulationCodes: Array.isArray(config?.errorSimulationCodes)
+      ? config.errorSimulationCodes.filter((code): code is number => typeof code === 'number')
+      : defaults.errorSimulationCodes,
+    rateLimitingEnabled:
+      typeof config?.rateLimitingEnabled === 'boolean'
+        ? config.rateLimitingEnabled
+        : defaults.rateLimitingEnabled,
+    rateLimitingRpm:
+      typeof config?.rateLimitingRpm === 'number'
+        ? config.rateLimitingRpm
+        : defaults.rateLimitingRpm,
+    loggingLevel:
+      config?.loggingLevel === 'full' || config?.loggingLevel === 'off'
+        ? config.loggingLevel
+        : defaults.loggingLevel,
+    scope: config?.scope === 'unset' ? 'unset' : 'all',
+  };
+}
+
+export function buildSnapshotPayload(project: {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  globalConfig: SnapshotGlobalConfigSource | null;
+  endpoints: Array<{
+    method: string;
+    path: string;
+    description: string;
+    statusCode: number;
+    responseBody: unknown;
+    endpointConfig: SnapshotEndpointConfigSource | null;
+    scenarios: Array<SnapshotScenarioSource>;
+  }>;
+}): ProjectSnapshotPayload {
+  return {
+    project: {
+      id: project.id,
+      slug: project.slug,
+      name: project.name,
+      description: project.description,
+    },
+    globalConfig: normalizeSnapshotGlobalConfig(project.id, project.globalConfig),
+    endpoints: [...project.endpoints]
+      .sort((left, right) =>
+        buildSnapshotEndpointKey(left.method, left.path).localeCompare(
+          buildSnapshotEndpointKey(right.method, right.path)
+        )
+      )
+      .map((endpoint) => ({
+        method: endpoint.method.toUpperCase(),
+        path: endpoint.path,
+        description: endpoint.description,
+        statusCode: endpoint.statusCode,
+        responseBody: endpoint.responseBody,
+        endpointConfig: normalizeEndpointConfig(endpoint.endpointConfig),
+        scenarios: endpoint.scenarios.map((scenario) => ({
+          name: scenario.name,
+          type:
+            scenario.type === 'error' || scenario.type === 'timeout' || scenario.type === 'empty'
+              ? scenario.type
+              : 'success',
+          statusCode: scenario.statusCode,
+          body: scenario.body,
+          delayMs: scenario.delayMs,
+          weight: scenario.weight,
+        })),
+      })),
+  };
+}
+
+async function loadSnapshotRecord(
+  projectId: string,
+  snapshotId: string
+): Promise<ProjectSnapshotRecord> {
+  const snapshot = await prisma.projectSnapshot.findFirst({
+    where: { id: snapshotId, projectId },
+  });
+
+  if (!snapshot) {
+    throw new AppError(404, 'Snapshot not found');
+  }
+
+  return snapshot as ProjectSnapshotRecord;
+}
+
+export async function listProjectSnapshots(actor: AuthenticatedActor, projectId: string) {
+  await authorizeProjectAccess(actor, projectId, 'read');
+
+  const snapshots = await prisma.projectSnapshot.findMany({
+    where: { projectId },
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+  });
+
+  return {
+    items: (snapshots as ProjectSnapshotRecord[]).map(toSnapshotSummary),
+  };
+}
+
+export async function getProjectSnapshotDetail(
+  actor: AuthenticatedActor,
+  projectId: string,
+  snapshotId: string
+) {
+  await authorizeProjectAccess(actor, projectId, 'read');
+  const snapshot = await loadSnapshotRecord(projectId, snapshotId);
+  return toSnapshotDetail(snapshot);
+}
+
+export async function createProjectSnapshot(
+  actor: AuthenticatedActor,
+  projectId: string,
+  input: CreateProjectSnapshotInput
+) {
+  const projectAccess = await authorizeProjectAccess(actor, projectId, 'mutate');
+
+  return prisma.$transaction(async (tx) => {
+    const creatorProfile = await tx.user.findUnique({
+      where: { id: actor.userId },
+      select: { email: true, displayName: true },
+    });
+    const project = await tx.project.findUniqueOrThrow({
+      where: { id: projectId },
+      include: {
+        globalConfig: true,
+        endpoints: {
+          include: {
+            endpointConfig: true,
+            scenarios: {
+              orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+            },
+          },
+          orderBy: [{ method: 'asc' }, { path: 'asc' }, { id: 'asc' }],
+        },
+      },
+    });
+
+    const payload = buildSnapshotPayload(project);
+    const snapshot = (await tx.projectSnapshot.create({
+      data: {
+        projectId,
+        name: input.name,
+        description: input.description ?? '',
+        createdByUserId: actor.userId,
+        createdByEmail: creatorProfile?.email ?? null,
+        createdByDisplayName: creatorProfile?.displayName ?? null,
+        payload: toPrismaJson(payload),
+      },
+    })) as ProjectSnapshotRecord;
+
+    await writeAuditEvent(tx, {
+      actor,
+      workspaceId: projectAccess.workspaceId ?? '',
+      projectId,
+      resourceType: 'snapshot',
+      resourceId: snapshot.id,
+      action: 'created',
+      summary: `Created snapshot ${snapshot.name}`,
+      metadata: {
+        snapshotName: snapshot.name,
+        endpointCount: payload.endpoints.length,
+      },
+    });
+
+    return toSnapshotSummary(snapshot);
+  });
+}
+
+export async function restoreProjectSnapshot(
+  actor: AuthenticatedActor,
+  projectId: string,
+  snapshotId: string
+) {
+  const projectAccess = await authorizeProjectAccess(actor, projectId, 'mutate');
+  const snapshot = await loadSnapshotRecord(projectId, snapshotId);
+  const detail = toSnapshotDetail(snapshot);
+
+  await prisma.$transaction(async (tx) => {
+    await tx.project.update({
+      where: { id: projectId },
+      data: {
+        name: detail.payload.project.name,
+        description: detail.payload.project.description,
+      },
+    });
+
+    await tx.globalConfig.upsert({
+      where: { projectId },
+      update: {
+        latencyEnabled: detail.payload.globalConfig.latencyEnabled,
+        latencyMinMs: detail.payload.globalConfig.latencyMinMs,
+        latencyMaxMs: detail.payload.globalConfig.latencyMaxMs,
+        latencyMode: detail.payload.globalConfig.latencyMode,
+        errorSimulationEnabled: detail.payload.globalConfig.errorSimulationEnabled,
+        errorSimulationRate: detail.payload.globalConfig.errorSimulationRate,
+        errorSimulationCodes: detail.payload.globalConfig.errorSimulationCodes,
+        rateLimitingEnabled: detail.payload.globalConfig.rateLimitingEnabled,
+        rateLimitingRpm: detail.payload.globalConfig.rateLimitingRpm,
+        loggingLevel: detail.payload.globalConfig.loggingLevel,
+        scope: 'all',
+      },
+      create: {
+        projectId,
+        latencyEnabled: detail.payload.globalConfig.latencyEnabled,
+        latencyMinMs: detail.payload.globalConfig.latencyMinMs,
+        latencyMaxMs: detail.payload.globalConfig.latencyMaxMs,
+        latencyMode: detail.payload.globalConfig.latencyMode,
+        errorSimulationEnabled: detail.payload.globalConfig.errorSimulationEnabled,
+        errorSimulationRate: detail.payload.globalConfig.errorSimulationRate,
+        errorSimulationCodes: detail.payload.globalConfig.errorSimulationCodes,
+        rateLimitingEnabled: detail.payload.globalConfig.rateLimitingEnabled,
+        rateLimitingRpm: detail.payload.globalConfig.rateLimitingRpm,
+        loggingLevel: detail.payload.globalConfig.loggingLevel,
+        scope: 'all',
+      },
+    });
+
+    const liveEndpoints = await tx.endpoint.findMany({
+      where: { projectId },
+      select: { id: true, method: true, path: true },
+    });
+    const plan = planSnapshotEndpointReconciliation(detail.payload.endpoints, liveEndpoints);
+    const liveByKey = new Map(
+      liveEndpoints.map((endpoint) => [
+        buildSnapshotEndpointKey(endpoint.method, endpoint.path),
+        endpoint,
+      ])
+    );
+
+    for (const endpoint of detail.payload.endpoints) {
+      const key = buildSnapshotEndpointKey(endpoint.method, endpoint.path);
+      const existing = liveByKey.get(key);
+      const restored = existing
+        ? await tx.endpoint.update({
+            where: { id: existing.id },
+            data: {
+              description: endpoint.description,
+              statusCode: endpoint.statusCode,
+              responseBody: toPrismaJson(endpoint.responseBody),
+            },
+            select: { id: true },
+          })
+        : await tx.endpoint.create({
+            data: {
+              projectId,
+              method: endpoint.method,
+              path: endpoint.path,
+              description: endpoint.description,
+              statusCode: endpoint.statusCode,
+              responseBody: toPrismaJson(endpoint.responseBody),
+            },
+            select: { id: true },
+          });
+
+      await tx.endpointConfig.upsert({
+        where: { endpointId: restored.id },
+        update: {
+          latencyMode: endpoint.endpointConfig.latencyMode,
+          fixedDelayMs: endpoint.endpointConfig.fixedDelayMs,
+          minDelayMs: endpoint.endpointConfig.minDelayMs,
+          maxDelayMs: endpoint.endpointConfig.maxDelayMs,
+          errorRate: endpoint.endpointConfig.errorRate,
+          useScenarioWeights: endpoint.endpointConfig.useScenarioWeights,
+        },
+        create: {
+          endpointId: restored.id,
+          latencyMode: endpoint.endpointConfig.latencyMode,
+          fixedDelayMs: endpoint.endpointConfig.fixedDelayMs,
+          minDelayMs: endpoint.endpointConfig.minDelayMs,
+          maxDelayMs: endpoint.endpointConfig.maxDelayMs,
+          errorRate: endpoint.endpointConfig.errorRate,
+          useScenarioWeights: endpoint.endpointConfig.useScenarioWeights,
+        },
+      });
+
+      await tx.scenario.deleteMany({ where: { endpointId: restored.id } });
+      if (endpoint.scenarios.length > 0) {
+        await tx.scenario.createMany({
+          data: endpoint.scenarios.map((scenario) => ({
+            endpointId: restored.id,
+            name: scenario.name,
+            type: scenario.type,
+            statusCode: scenario.statusCode,
+            body: toPrismaJson(scenario.body),
+            delayMs: scenario.delayMs,
+            weight: scenario.weight,
+          })),
+        });
+      }
+    }
+
+    if (plan.deleteIds.length > 0) {
+      await tx.endpoint.deleteMany({ where: { id: { in: plan.deleteIds } } });
+    }
+
+    await writeAuditEvent(tx, {
+      actor,
+      workspaceId: projectAccess.workspaceId ?? '',
+      projectId,
+      resourceType: 'snapshot',
+      resourceId: snapshot.id,
+      action: 'restored',
+      summary: `Restored snapshot ${snapshot.name}`,
+      metadata: {
+        snapshotName: snapshot.name,
+        restoredEndpointCount: detail.payload.endpoints.length,
+        deletedEndpointCount: plan.deleteIds.length,
+      },
+    });
+  });
+
+  return { restoredSnapshotId: snapshot.id };
+}

--- a/apps/web/src/app/features/audit-history/adapters/audit-history-api.mapper.ts
+++ b/apps/web/src/app/features/audit-history/adapters/audit-history-api.mapper.ts
@@ -15,6 +15,7 @@ function resolveResourceLabel(event: ApiAuditEventDto): string {
   const method = typeof metadata['method'] === 'string' ? metadata['method'] : null;
   const projectName = typeof metadata['projectName'] === 'string' ? metadata['projectName'] : null;
   const scenarioName = typeof metadata['scenarioName'] === 'string' ? metadata['scenarioName'] : null;
+  const snapshotName = typeof metadata['snapshotName'] === 'string' ? metadata['snapshotName'] : null;
 
   switch (event.resourceType) {
     case 'endpoint':
@@ -27,9 +28,17 @@ function resolveResourceLabel(event: ApiAuditEventDto): string {
       return scenarioName ?? event.resourceId;
     case 'global-config':
       return 'Global config';
+    case 'snapshot':
+      return snapshotName ?? event.resourceId;
     default:
       return event.resourceId;
   }
+}
+
+function resolveActionLabel(event: ApiAuditEventDto): string {
+  if (event.resourceType === 'snapshot' && event.action === 'created') return 'saved snapshot';
+  if (event.resourceType === 'snapshot' && event.action === 'restored') return 'restored snapshot';
+  return event.action;
 }
 
 export function mapAuditEventFromApi(event: ApiAuditEventDto): AuditHistoryEntry {
@@ -43,6 +52,7 @@ export function mapAuditEventFromApi(event: ApiAuditEventDto): AuditHistoryEntry
     resourceId: event.resourceId,
     resourceLabel: resolveResourceLabel(event),
     action: event.action,
+    actionLabel: resolveActionLabel(event),
     summary: event.summary,
     metadata: event.metadata,
     createdAt: event.createdAt,

--- a/apps/web/src/app/features/audit-history/audit-history.component.html
+++ b/apps/web/src/app/features/audit-history/audit-history.component.html
@@ -19,10 +19,15 @@
           <div class="audit-history__meta">
             <span class="audit-history__time">{{ entry.timeLabel }}</span>
             <span class="audit-history__actor">{{ entry.actorLabel }}</span>
-            <span class="audit-history__action">{{ entry.action }}</span>
+            <span class="audit-history__action">{{ entry.actionLabel }}</span>
             <span class="audit-history__resource">{{ entry.resourceLabel }}</span>
           </div>
           <p class="audit-history__summary">{{ entry.summary }}</p>
+          @if (canRestoreEntry(entry)) {
+            <button type="button" class="audit-history__load-more" (click)="requestRestore(entry)">
+              Restore snapshot
+            </button>
+          }
         </li>
       }
     </ul>

--- a/apps/web/src/app/features/audit-history/audit-history.component.spec.ts
+++ b/apps/web/src/app/features/audit-history/audit-history.component.spec.ts
@@ -1,6 +1,11 @@
 import { Injector, runInInjectionContext } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { provideAngularReactiveSchedulers, setupAngularVitest } from '../../testing/angular-vitest';
+import {
+  provideAngularReactiveSchedulers,
+  resolveAngularExternalResources,
+  setupAngularVitest,
+} from '../../testing/angular-vitest';
 import type { AuditHistoryListResult, AuditHistoryEntry } from './models/audit-history.model';
 import { AuditHistoryRepository } from './data-access/audit-history.repository';
 import { AuditHistoryComponent } from './audit-history.component';
@@ -40,6 +45,7 @@ const newestEntry: AuditHistoryEntry = {
   resourceId: 'endpoint-1',
   resourceLabel: 'GET /users',
   action: 'updated',
+  actionLabel: 'updated',
   summary: 'Updated endpoint GET /users',
   metadata: { endpointPath: '/users', method: 'GET' },
   createdAt: '2026-04-14T12:00:02.000Z',
@@ -50,6 +56,7 @@ const olderEntry: AuditHistoryEntry = {
   ...newestEntry,
   id: 'audit-1',
   action: 'created',
+  actionLabel: 'created',
   summary: 'Created endpoint GET /users',
   createdAt: '2026-04-14T12:00:01.000Z',
   timeLabel: '12:00:01',
@@ -59,6 +66,33 @@ async function flushAsyncWork(cycles = 6): Promise<void> {
   for (let index = 0; index < cycles; index += 1) {
     await Promise.resolve();
   }
+}
+
+async function renderComponent(
+  listEvents: AuditHistoryRepository['listEvents'],
+  inputs?: Partial<{
+    projectId: string;
+    canRestoreSnapshots: boolean;
+  }>,
+): Promise<HTMLElement> {
+  await resolveAngularExternalResources();
+  await TestBed.configureTestingModule({
+    imports: [AuditHistoryComponent],
+    providers: [{ provide: AuditHistoryRepository, useValue: { listEvents } }],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(AuditHistoryComponent);
+  const component = fixture.componentInstance as unknown as {
+    projectId: () => string;
+    canRestoreSnapshots: () => boolean;
+  };
+  component.projectId = () => inputs?.projectId ?? 'project-1';
+  component.canRestoreSnapshots = () => inputs?.canRestoreSnapshots ?? false;
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+
+  return fixture.nativeElement as HTMLElement;
 }
 
 describe('AuditHistoryComponent', () => {
@@ -139,5 +173,37 @@ describe('AuditHistoryComponent', () => {
     });
     expect(component.entries().map((entry) => entry.id)).toEqual(['audit-2', 'audit-1', 'audit-0']);
     expect(component.loadingOlder()).toBe(false);
+  });
+
+  it('does not render the restore snapshot CTA for read-only viewers', async () => {
+    const snapshotEntry: AuditHistoryEntry = {
+      id: 'audit-snapshot-1',
+      actor: { userId: 'user-1', email: 'owner@example.com', displayName: 'Owner User' },
+      actorLabel: 'Owner User',
+      workspaceId: 'workspace-1',
+      projectId: 'project-1',
+      resourceType: 'snapshot',
+      resourceId: 'snapshot-1',
+      resourceLabel: 'Before imports',
+      action: 'created',
+      actionLabel: 'saved snapshot',
+      summary: 'Created snapshot Before imports',
+      metadata: { snapshotName: 'Before imports' },
+      createdAt: '2026-04-14T12:00:00.000Z',
+      timeLabel: '12:00:00',
+    };
+    const listEvents = vi
+      .fn<AuditHistoryRepository['listEvents']>()
+      .mockResolvedValue(createListResponse([snapshotEntry]));
+
+    const element = await renderComponent(listEvents, {
+      projectId: 'project-1',
+      canRestoreSnapshots: false,
+    });
+
+    expect(element.textContent).toContain('Created snapshot Before imports');
+    expect(
+      Array.from(element.querySelectorAll('button')).some((button) => button.textContent?.includes('Restore snapshot')),
+    ).toBe(false);
   });
 });

--- a/apps/web/src/app/features/audit-history/audit-history.component.ts
+++ b/apps/web/src/app/features/audit-history/audit-history.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, signal, untracked } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal, untracked } from '@angular/core';
 import { AuditHistoryRepository } from './data-access/audit-history.repository';
 import type { AuditHistoryCursor, AuditHistoryEntry } from './models/audit-history.model';
 
@@ -26,6 +26,8 @@ export class AuditHistoryComponent {
   private activeProjectId: string | null = null;
 
   readonly projectId = input('');
+  readonly canRestoreSnapshots = input(false);
+  readonly restoreSnapshotRequested = output<string>();
 
   protected readonly entries = signal<AuditHistoryEntry[]>([]);
   protected readonly loading = signal(false);
@@ -44,6 +46,15 @@ export class AuditHistoryComponent {
   }
 
   protected readonly emptyStateMessage = () => 'No audit history yet for this project.';
+
+  protected canRestoreEntry(entry: AuditHistoryEntry): boolean {
+    return this.canRestoreSnapshots() && entry.resourceType === 'snapshot';
+  }
+
+  protected requestRestore(entry: AuditHistoryEntry): void {
+    if (!this.canRestoreEntry(entry)) return;
+    this.restoreSnapshotRequested.emit(entry.resourceId);
+  }
 
   async loadProject(projectId: string): Promise<void> {
     this.loading.set(true);

--- a/apps/web/src/app/features/audit-history/models/audit-history.model.ts
+++ b/apps/web/src/app/features/audit-history/models/audit-history.model.ts
@@ -1,5 +1,5 @@
-export type AuditResourceType = 'project' | 'endpoint' | 'scenario' | 'global-config' | 'endpoint-config';
-export type AuditAction = 'created' | 'updated' | 'deleted';
+export type AuditResourceType = 'project' | 'endpoint' | 'scenario' | 'global-config' | 'endpoint-config' | 'snapshot';
+export type AuditAction = 'created' | 'updated' | 'deleted' | 'restored';
 
 export interface AuditHistoryActor {
   userId: string;
@@ -22,6 +22,7 @@ export interface AuditHistoryEntry {
   resourceId: string;
   resourceLabel: string;
   action: AuditAction;
+  actionLabel: string;
   summary: string;
   metadata: unknown;
   createdAt: string;

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.spec.ts
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.spec.ts
@@ -1,5 +1,5 @@
 import { Injector, runInInjectionContext } from '@angular/core';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { provideAngularReactiveSchedulers, setupAngularVitest } from '../../../../testing/angular-vitest';
 import type { DashboardProject } from '../../models/dashboard-project.model';
 import { MainDashboardUtilitySidebarComponent } from './main-dashboard-utility-sidebar.component';
@@ -16,6 +16,9 @@ type MainDashboardUtilityHarness = MainDashboardUtilitySidebarComponent & {
     timeLabel: string;
   }>;
   globalConfigRows: () => Array<{ label: string; badge: string; tone: 'neutral' | 'success' }>;
+  quickActions: Array<{ id: string; title: string; subtitle: string }>;
+  onQuickAction(id: string): void;
+  createSnapshot: { emit: () => void };
 };
 
 function bindProjectInput(component: { project: unknown }, project: DashboardProject): void {
@@ -115,5 +118,47 @@ describe('MainDashboardUtilitySidebarComponent', () => {
     bindProjectInput(component, { ...projectFixture, recentRequests: [] });
 
     expect(component.recentRequests()).toEqual([]);
+  });
+
+  it('adds a create snapshot quick action gated through the mutation affordance', () => {
+    const injector = Injector.create({ providers: [...provideAngularReactiveSchedulers()] });
+    const component = runInInjectionContext(
+      injector,
+      () => new MainDashboardUtilitySidebarComponent(),
+    ) as unknown as MainDashboardUtilityHarness & { project: () => DashboardProject; canMutate: () => boolean };
+
+    bindProjectInput(component, projectFixture);
+    component.canMutate = (() => true) as typeof component.canMutate;
+    const emitSpy = vi.spyOn(component.createSnapshot, 'emit');
+
+    expect(component.quickActions.map((action) => action.id)).toContain('snapshot');
+
+    component.onQuickAction('snapshot');
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps snapshot quick actions read-only when the workspace cannot mutate', () => {
+    const injector = Injector.create({ providers: [...provideAngularReactiveSchedulers()] });
+    const component = runInInjectionContext(
+      injector,
+      () => new MainDashboardUtilitySidebarComponent(),
+    ) as unknown as MainDashboardUtilityHarness & { project: () => DashboardProject; canMutate: () => boolean };
+
+    bindProjectInput(component, {
+      ...projectFixture,
+      workspace: {
+        ...projectFixture.workspace,
+        role: 'viewer',
+        capabilities: { canEdit: false, canManageMembers: false },
+      },
+    });
+    component.canMutate = (() => false) as typeof component.canMutate;
+    const emitSpy = vi.spyOn(component.createSnapshot, 'emit');
+
+    component.onQuickAction('snapshot');
+
+    expect(component.quickActions.map((action) => action.id)).toContain('snapshot');
+    expect(emitSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.ts
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.ts
@@ -24,7 +24,7 @@ export interface UtilitySidebarRequestItem {
 }
 
 interface UtilityQuickAction {
-  id: 'create' | 'test' | 'export' | 'import';
+  id: 'create' | 'snapshot' | 'test' | 'export' | 'import';
   title: string;
   subtitle: string;
   icon: 'plus' | 'play' | 'download' | 'upload';
@@ -57,6 +57,7 @@ export class MainDashboardUtilitySidebarComponent {
   readonly workspaceMemberMutationPending = input(false);
 
   readonly createEndpoint = output<void>();
+  readonly createSnapshot = output<void>();
   readonly testAllEndpoints = output<void>();
   readonly exportConfig = output<void>();
   readonly importEndpoints = output<void>();
@@ -70,6 +71,12 @@ export class MainDashboardUtilitySidebarComponent {
       title: 'Create endpoint',
       subtitle: 'Add a new mock endpoint',
       icon: 'plus' as const,
+    },
+    {
+      id: 'snapshot',
+      title: 'Create snapshot',
+      subtitle: 'Save the current project state',
+      icon: 'download' as const,
     },
     {
       id: 'test',
@@ -174,6 +181,10 @@ export class MainDashboardUtilitySidebarComponent {
       case 'create':
         if (!this.canMutate()) return;
         this.createEndpoint.emit();
+        break;
+      case 'snapshot':
+        if (!this.canMutate()) return;
+        this.createSnapshot.emit();
         break;
       case 'test':
         this.testAllEndpoints.emit();

--- a/apps/web/src/app/features/project-snapshots/adapters/project-snapshot-api.mapper.spec.ts
+++ b/apps/web/src/app/features/project-snapshots/adapters/project-snapshot-api.mapper.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { mapProjectSnapshotDetailFromApi, mapProjectSnapshotFromApi } from './project-snapshot-api.mapper';
+
+describe('project snapshot api mapper', () => {
+  it('maps snapshot actor labels and canonical payloads for restore flows', () => {
+    const snapshot = mapProjectSnapshotFromApi({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before imports',
+      description: 'Safe point',
+      createdAt: '2026-04-17T10:00:00.000Z',
+      createdBy: { userId: 'user-1', email: 'owner@example.com', displayName: 'Owner User' },
+    });
+
+    const detail = mapProjectSnapshotDetailFromApi({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before imports',
+      description: 'Safe point',
+      createdAt: '2026-04-17T10:00:00.000Z',
+      createdBy: { userId: 'user-1', email: 'owner@example.com', displayName: 'Owner User' },
+      payload: {
+        project: { id: 'project-1', slug: 'users-api', name: 'Users API', description: 'Baseline' },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: false,
+          latencyMinMs: 0,
+          latencyMaxMs: 1000,
+          latencyMode: 'fixed',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 60,
+          loggingLevel: 'basic',
+          scope: 'all',
+        },
+        endpoints: [],
+      },
+    });
+
+    expect(snapshot.createdBy.label).toBe('Owner User');
+    expect(detail.payload.project.name).toBe('Users API');
+    expect(detail.payload.endpoints).toEqual([]);
+  });
+});

--- a/apps/web/src/app/features/project-snapshots/adapters/project-snapshot-api.mapper.ts
+++ b/apps/web/src/app/features/project-snapshots/adapters/project-snapshot-api.mapper.ts
@@ -1,0 +1,33 @@
+import type {
+  ProjectSnapshotActorDto,
+  ProjectSnapshotDetailDto,
+  ProjectSnapshotDto,
+} from '../../../shared/http/api.types';
+import type { ProjectSnapshot, ProjectSnapshotDetail } from '../models/project-snapshot.model';
+
+function mapSnapshotActor(actor: ProjectSnapshotActorDto) {
+  return {
+    userId: actor.userId,
+    email: actor.email,
+    displayName: actor.displayName,
+    label: actor.displayName ?? actor.email ?? actor.userId,
+  };
+}
+
+export function mapProjectSnapshotFromApi(snapshot: ProjectSnapshotDto): ProjectSnapshot {
+  return {
+    id: snapshot.id,
+    projectId: snapshot.projectId,
+    name: snapshot.name,
+    description: snapshot.description,
+    createdAt: snapshot.createdAt,
+    createdBy: mapSnapshotActor(snapshot.createdBy),
+  };
+}
+
+export function mapProjectSnapshotDetailFromApi(snapshot: ProjectSnapshotDetailDto): ProjectSnapshotDetail {
+  return {
+    ...mapProjectSnapshotFromApi(snapshot),
+    payload: snapshot.payload,
+  };
+}

--- a/apps/web/src/app/features/project-snapshots/data-access/project-snapshots.repository.spec.ts
+++ b/apps/web/src/app/features/project-snapshots/data-access/project-snapshots.repository.spec.ts
@@ -1,0 +1,88 @@
+import { Injector, runInInjectionContext } from '@angular/core';
+import { describe, expect, it, vi } from 'vitest';
+import { setupAngularVitest } from '../../../testing/angular-vitest';
+import { ApiClient } from '../../../shared/http/api-client';
+import { ProjectSnapshotsRepository } from './project-snapshots.repository';
+
+setupAngularVitest();
+
+describe('ProjectSnapshotsRepository', () => {
+  function createRepository(api: object) {
+    const injector = Injector.create({
+      providers: [{ provide: ApiClient, useValue: api }],
+    });
+
+    return runInInjectionContext(injector, () => new ProjectSnapshotsRepository());
+  }
+
+  it('maps snapshot list, detail, create, and restore contracts through the dedicated project snapshot endpoints', async () => {
+    const api = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({
+          items: [
+            {
+              id: 'snapshot-1',
+              projectId: 'project-1',
+              name: 'Before imports',
+              description: 'Safe point',
+              createdAt: '2026-04-17T10:00:00.000Z',
+              createdBy: { userId: 'user-1', email: 'owner@example.com', displayName: 'Owner User' },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          id: 'snapshot-1',
+          projectId: 'project-1',
+          name: 'Before imports',
+          description: 'Safe point',
+          createdAt: '2026-04-17T10:00:00.000Z',
+          createdBy: { userId: 'user-1', email: 'owner@example.com', displayName: 'Owner User' },
+          payload: {
+            project: { id: 'project-1', slug: 'users-api', name: 'Users API', description: 'Baseline' },
+            globalConfig: {
+              projectId: 'project-1',
+              latencyEnabled: false,
+              latencyMinMs: 0,
+              latencyMaxMs: 1000,
+              latencyMode: 'fixed',
+              errorSimulationEnabled: false,
+              errorSimulationRate: 0,
+              errorSimulationCodes: [500],
+              rateLimitingEnabled: false,
+              rateLimitingRpm: 60,
+              loggingLevel: 'basic',
+              scope: 'all',
+            },
+            endpoints: [],
+          },
+        }),
+      post: vi
+        .fn()
+        .mockResolvedValueOnce({
+          id: 'snapshot-2',
+          projectId: 'project-1',
+          name: 'Before restore',
+          description: '',
+          createdAt: '2026-04-17T10:05:00.000Z',
+          createdBy: { userId: 'user-1', email: 'owner@example.com', displayName: 'Owner User' },
+        })
+        .mockResolvedValueOnce({ restoredSnapshotId: 'snapshot-1' }),
+    };
+
+    const repository = createRepository(api);
+    const list = await repository.list('project-1');
+    const detail = await repository.get('project-1', 'snapshot-1');
+    const created = await repository.create('project-1', { name: 'Before restore' });
+    const restored = await repository.restore('project-1', 'snapshot-1');
+
+    expect(api.get).toHaveBeenNthCalledWith(1, '/projects/project-1/snapshots');
+    expect(api.get).toHaveBeenNthCalledWith(2, '/projects/project-1/snapshots/snapshot-1');
+    expect(api.post).toHaveBeenNthCalledWith(1, '/projects/project-1/snapshots', { name: 'Before restore' });
+    expect(api.post).toHaveBeenNthCalledWith(2, '/projects/project-1/snapshots/snapshot-1/restore', {});
+    expect(list.items[0]?.createdBy.label).toBe('Owner User');
+    expect(detail.payload.project.slug).toBe('users-api');
+    expect(created.name).toBe('Before restore');
+    expect(restored.restoredSnapshotId).toBe('snapshot-1');
+  });
+});

--- a/apps/web/src/app/features/project-snapshots/data-access/project-snapshots.repository.ts
+++ b/apps/web/src/app/features/project-snapshots/data-access/project-snapshots.repository.ts
@@ -1,0 +1,39 @@
+import { Injectable, inject } from '@angular/core';
+import { ApiClient } from '../../../shared/http/api-client';
+import type {
+  CreateProjectSnapshotDto,
+  ProjectSnapshotDetailDto,
+  ProjectSnapshotListDto,
+  RestoreProjectSnapshotResponseDto,
+} from '../../../shared/http/api.types';
+import { mapProjectSnapshotDetailFromApi, mapProjectSnapshotFromApi } from '../adapters/project-snapshot-api.mapper';
+
+@Injectable({ providedIn: 'root' })
+export class ProjectSnapshotsRepository {
+  private readonly api = inject(ApiClient);
+
+  async list(projectId: string) {
+    const response = await this.api.get<ProjectSnapshotListDto>(`/projects/${projectId}/snapshots`);
+    return { items: response.items.map(mapProjectSnapshotFromApi) };
+  }
+
+  async get(projectId: string, snapshotId: string) {
+    const response = await this.api.get<ProjectSnapshotDetailDto>(`/projects/${projectId}/snapshots/${snapshotId}`);
+    return mapProjectSnapshotDetailFromApi(response);
+  }
+
+  async create(projectId: string, input: CreateProjectSnapshotDto) {
+    const response = await this.api.post<
+      ProjectSnapshotDetailDto | ProjectSnapshotListDto['items'][number],
+      CreateProjectSnapshotDto
+    >(`/projects/${projectId}/snapshots`, input);
+    return mapProjectSnapshotFromApi(response as ProjectSnapshotListDto['items'][number]);
+  }
+
+  restore(projectId: string, snapshotId: string) {
+    return this.api.post<RestoreProjectSnapshotResponseDto, Record<string, never>>(
+      `/projects/${projectId}/snapshots/${snapshotId}/restore`,
+      {},
+    );
+  }
+}

--- a/apps/web/src/app/features/project-snapshots/models/project-snapshot.model.ts
+++ b/apps/web/src/app/features/project-snapshots/models/project-snapshot.model.ts
@@ -1,0 +1,64 @@
+import type { GlobalConfigDto } from '../../../shared/http/api.types';
+
+export interface ProjectSnapshotActor {
+  userId: string;
+  email: string | null;
+  displayName: string | null;
+  label: string;
+}
+
+export interface ProjectSnapshotPayloadEndpointConfig {
+  latencyMode: 'fixed' | 'range';
+  fixedDelayMs: number;
+  minDelayMs: number;
+  maxDelayMs: number;
+  errorRate: number;
+  useScenarioWeights: boolean;
+}
+
+export interface ProjectSnapshotPayloadScenario {
+  name: string;
+  type: 'success' | 'error' | 'timeout' | 'empty';
+  statusCode: number;
+  body: unknown;
+  delayMs: number;
+  weight: number;
+}
+
+export interface ProjectSnapshotPayloadEndpoint {
+  method: string;
+  path: string;
+  description: string;
+  statusCode: number;
+  responseBody: unknown;
+  endpointConfig: ProjectSnapshotPayloadEndpointConfig;
+  scenarios: ProjectSnapshotPayloadScenario[];
+}
+
+export interface ProjectSnapshotPayload {
+  project: {
+    id: string;
+    slug: string;
+    name: string;
+    description: string;
+  };
+  globalConfig: GlobalConfigDto;
+  endpoints: ProjectSnapshotPayloadEndpoint[];
+}
+
+export interface ProjectSnapshot {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  createdBy: ProjectSnapshotActor;
+}
+
+export interface ProjectSnapshotDetail extends ProjectSnapshot {
+  payload: ProjectSnapshotPayload;
+}
+
+export interface ProjectSnapshotListResult {
+  items: ProjectSnapshot[];
+}

--- a/apps/web/src/app/features/workspace-shell/models/workspace-shell.model.ts
+++ b/apps/web/src/app/features/workspace-shell/models/workspace-shell.model.ts
@@ -36,3 +36,8 @@ export interface CreateProjectAiFlowState {
   message: string;
   retryable: boolean;
 }
+
+export interface SnapshotHistoryState {
+  loadedForProjectId: string | null;
+  latestSnapshotId: string | null;
+}

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.audit-history.integration.spec.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.audit-history.integration.spec.ts
@@ -4,6 +4,7 @@ import { provideAngularReactiveSchedulers, setupAngularVitest } from '../../test
 import { FrontendAuthSessionService } from '../../shared/auth/frontend-auth-session.service';
 import { AuditHistoryComponent } from '../audit-history/audit-history.component';
 import { AuditHistoryRepository } from '../audit-history/data-access/audit-history.repository';
+import { ProjectSnapshotsRepository } from '../project-snapshots/data-access/project-snapshots.repository';
 import { ProjectsRepository } from '../main-dashboard/data-access/projects.repository';
 import { EndpointsRepository } from '../endpoints/data-access/endpoints.repository';
 import { GlobalConfigRepository } from '../global-config/data-access/global-config.repository';
@@ -39,6 +40,13 @@ describe('WorkspaceShellComponent audit history integration', () => {
 
   const auditHistoryRepository = {
     listEvents: vi.fn(),
+  };
+
+  const projectSnapshotsRepository = {
+    list: vi.fn(),
+    get: vi.fn(),
+    create: vi.fn(),
+    restore: vi.fn(),
   };
 
   const endpointsRepository = {
@@ -87,8 +95,13 @@ describe('WorkspaceShellComponent audit history integration', () => {
     projectsRepository.listProjects.mockReset();
     projectsRepository.getProject.mockReset();
     auditHistoryRepository.listEvents.mockReset();
+    projectSnapshotsRepository.list.mockReset();
+    projectSnapshotsRepository.get.mockReset();
+    projectSnapshotsRepository.create.mockReset();
+    projectSnapshotsRepository.restore.mockReset();
     workspaceMembersRepository.listMembers.mockReset();
     workspaceMembersRepository.listMembers.mockResolvedValue([]);
+    projectSnapshotsRepository.list.mockResolvedValue({ items: [] });
   });
 
   async function renderHistorySnapshot(injector: Injector, projectId: string): Promise<string> {
@@ -112,6 +125,7 @@ describe('WorkspaceShellComponent audit history integration', () => {
         ...provideAngularReactiveSchedulers(),
         { provide: ProjectsRepository, useValue: projectsRepository },
         { provide: AuditHistoryRepository, useValue: auditHistoryRepository },
+        { provide: ProjectSnapshotsRepository, useValue: projectSnapshotsRepository },
         { provide: EndpointsRepository, useValue: endpointsRepository },
         { provide: GlobalConfigRepository, useValue: globalConfigRepository },
         { provide: WorkspaceMembersRepository, useValue: workspaceMembersRepository },
@@ -178,6 +192,7 @@ describe('WorkspaceShellComponent audit history integration', () => {
           resourceId: 'project-1',
           resourceLabel: 'Workspace project',
           action: 'created',
+          actionLabel: 'created',
           summary: 'Created project Workspace project',
           metadata: { projectName: 'Workspace project' },
           createdAt: '2026-04-14T12:00:00.000Z',
@@ -200,5 +215,133 @@ describe('WorkspaceShellComponent audit history integration', () => {
     expect(snapshot).toContain('Owner User');
     expect(snapshot).toContain('created');
     expect(snapshot).toContain('Workspace project');
+  });
+
+  it('loads snapshot history for the selected project and restores from snapshot audit entries', async () => {
+    projectsRepository.listProjects.mockResolvedValue({
+      items: [
+        {
+          id: 'project-1',
+          name: 'Workspace project',
+          slug: 'workspace-project',
+          workspace: { id: 'workspace-1', role: 'owner', capabilities: { canEdit: true, canManageMembers: true } },
+          status: 'running',
+          mockUrl: 'https://mock.example.com/workspace-project',
+          description: 'Live backend project',
+          lastUpdatedRelative: 'just now',
+          metrics: { totalEndpoints: 1, totalScenarios: 1, avgLatencyMs: 84, errorRatePct: 0, totalRequests: 0 },
+          health: {
+            readyEndpoints: 1,
+            needsAttentionEndpoints: 0,
+            errorScenarioEndpoints: 0,
+            emptyScenarioEndpoints: 0,
+            timeoutScenarioEndpoints: 0,
+          },
+          endpointRows: [],
+          endpointRowsMeta: { total: 0, limit: 25, hasMore: false },
+          recentRequests: [],
+          configSummary: {
+            latency: { enabled: false, mode: 'fixed', minMs: 0, maxMs: 1000 },
+            errorSimulation: { enabled: false, ratePct: 0, codes: [500] },
+            rateLimiting: { enabled: false, rpm: 60 },
+            logging: { level: 'basic' },
+            scope: 'all',
+          },
+          endpoints: [],
+        },
+      ],
+      page: { limit: 25, offset: 0, total: 1, hasMore: false },
+    });
+    projectsRepository.getProject.mockImplementation(
+      async () => (await projectsRepository.listProjects.mock.results[0]!.value).items[0],
+    );
+    auditHistoryRepository.listEvents.mockResolvedValue({
+      items: [
+        {
+          id: 'audit-snapshot-1',
+          actor: { userId: 'user-1', email: 'owner@example.com', displayName: 'Owner User' },
+          actorLabel: 'Owner User',
+          workspaceId: 'workspace-1',
+          projectId: 'project-1',
+          resourceType: 'snapshot',
+          resourceId: 'snapshot-1',
+          resourceLabel: 'Before imports',
+          action: 'created',
+          actionLabel: 'saved snapshot',
+          summary: 'Created snapshot Before imports',
+          metadata: { snapshotName: 'Before imports' },
+          createdAt: '2026-04-14T12:00:00.000Z',
+          timeLabel: '12:00:00',
+        },
+      ],
+      nextCursor: null,
+      serverTime: '2026-04-14T12:00:05.000Z',
+    });
+    projectSnapshotsRepository.list.mockResolvedValue({
+      items: [
+        {
+          id: 'snapshot-1',
+          projectId: 'project-1',
+          name: 'Before imports',
+          description: '',
+          createdAt: '2026-04-14T12:00:00.000Z',
+          createdBy: { userId: 'user-1', email: 'owner@example.com', displayName: 'Owner User', label: 'Owner User' },
+        },
+      ],
+    });
+    projectSnapshotsRepository.get.mockResolvedValue({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before imports',
+      description: '',
+      createdAt: '2026-04-14T12:00:00.000Z',
+      createdBy: { userId: 'user-1', email: 'owner@example.com', displayName: 'Owner User', label: 'Owner User' },
+      payload: {
+        project: {
+          id: 'project-1',
+          slug: 'workspace-project',
+          name: 'Workspace project',
+          description: 'Live backend project',
+        },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: false,
+          latencyMinMs: 0,
+          latencyMaxMs: 1000,
+          latencyMode: 'fixed',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 60,
+          loggingLevel: 'basic',
+          scope: 'all',
+        },
+        endpoints: [],
+      },
+    });
+    projectSnapshotsRepository.restore.mockResolvedValue({ restoredSnapshotId: 'snapshot-1' });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const { component } = createComponent();
+    await flushAsyncWork();
+
+    component.selectNav('history');
+    await flushAsyncWork();
+    await (component as unknown as { createSnapshot(): void }).createSnapshot();
+    await flushAsyncWork();
+    await (component as unknown as { restoreSnapshot(snapshotId: string): Promise<void> }).restoreSnapshot(
+      'snapshot-1',
+    );
+    await flushAsyncWork();
+
+    expect(projectSnapshotsRepository.list).toHaveBeenCalledWith('project-1');
+    expect(projectSnapshotsRepository.create).toHaveBeenCalledWith(
+      'project-1',
+      expect.objectContaining({ name: expect.any(String) }),
+    );
+    expect(projectSnapshotsRepository.get).toHaveBeenCalledWith('project-1', 'snapshot-1');
+    expect(projectSnapshotsRepository.restore).toHaveBeenCalledWith('project-1', 'snapshot-1');
+    expect(confirmSpy).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.html
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.html
@@ -137,7 +137,11 @@
   </main>
 } @else if (activeNav() === 'history') {
   <main class="workspace__main" aria-label="Audit history">
-    <app-audit-history [projectId]="selectedProjectId()" />
+    <app-audit-history
+      [projectId]="selectedProjectId()"
+      [canRestoreSnapshots]="canMutateActiveWorkspace()"
+      (restoreSnapshotRequested)="restoreSnapshot($event)"
+    />
   </main>
 } @else if (activeNav() === 'endpoints') {
   <main class="workspace__main" aria-label="Endpoints">
@@ -173,6 +177,7 @@
       [workspaceMembersError]="workspaceMembersError()"
       [workspaceMemberMutationPending]="workspaceMemberMutationPending()"
       (createEndpoint)="createEndpoint()"
+      (createSnapshot)="createSnapshot()"
       (testAllEndpoints)="testAllEndpoints()"
       (exportConfig)="exportConfig()"
       (importEndpoints)="importEndpoints()"

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.spec.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.spec.ts
@@ -6,6 +6,7 @@ import { EndpointsRepository } from '../endpoints/data-access/endpoints.reposito
 import { GlobalConfigRepository } from '../global-config/data-access/global-config.repository';
 import type { GlobalConfig } from '../global-config/models/global-config.model';
 import { ProjectsRepository } from '../main-dashboard/data-access/projects.repository';
+import { ProjectSnapshotsRepository } from '../project-snapshots/data-access/project-snapshots.repository';
 import type { DashboardProject } from '../main-dashboard/models/dashboard-project.model';
 import type { EndpointPreview } from '../../shared/models/endpoint-preview.model';
 import { WorkspaceMembersRepository } from '../workspace-members/data-access/workspace-members.repository';
@@ -226,6 +227,13 @@ describe('WorkspaceShellComponent', () => {
     removeMember: vi.fn(),
   };
 
+  const projectSnapshotsRepository = {
+    list: vi.fn(),
+    get: vi.fn(),
+    create: vi.fn(),
+    restore: vi.fn(),
+  };
+
   const authSession = {
     snapshot: signal({
       state: 'authenticated',
@@ -257,6 +265,7 @@ describe('WorkspaceShellComponent', () => {
         { provide: ProjectsRepository, useValue: projectsRepository },
         { provide: EndpointsRepository, useValue: endpointsRepository },
         { provide: GlobalConfigRepository, useValue: globalConfigRepository },
+        { provide: ProjectSnapshotsRepository, useValue: projectSnapshotsRepository },
         { provide: WorkspaceMembersRepository, useValue: workspaceMembersRepository },
         { provide: FrontendAuthSessionService, useValue: authSession },
       ],
@@ -276,6 +285,10 @@ describe('WorkspaceShellComponent', () => {
     endpointsRepository.deleteEndpoint.mockReset();
     globalConfigRepository.getConfig.mockReset();
     globalConfigRepository.saveConfig.mockReset();
+    projectSnapshotsRepository.list.mockReset();
+    projectSnapshotsRepository.get.mockReset();
+    projectSnapshotsRepository.create.mockReset();
+    projectSnapshotsRepository.restore.mockReset();
     workspaceMembersRepository.listMembers.mockReset();
     workspaceMembersRepository.addMember.mockReset();
     workspaceMembersRepository.removeMember.mockReset();
@@ -287,6 +300,10 @@ describe('WorkspaceShellComponent', () => {
     authSession.canAccessProtectedRoutes.mockReset();
     authSession.handleProtectedApiError.mockReturnValue(false);
     authSession.canAccessProtectedRoutes.mockReturnValue(true);
+    projectSnapshotsRepository.list.mockResolvedValue({ items: [] });
+    projectSnapshotsRepository.get.mockResolvedValue(null);
+    projectSnapshotsRepository.create.mockResolvedValue(null);
+    projectSnapshotsRepository.restore.mockResolvedValue(undefined);
     authSession.snapshot.set({
       state: 'authenticated',
       userId: 'user-1',

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.ts
@@ -2,6 +2,8 @@ import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@a
 import { ApiError } from '../../shared/http/api-error.mapper';
 import { FrontendAuthSessionService } from '../../shared/auth/frontend-auth-session.service';
 import { AuditHistoryComponent } from '../audit-history/audit-history.component';
+import { ProjectSnapshotsRepository } from '../project-snapshots/data-access/project-snapshots.repository';
+import type { ProjectSnapshot } from '../project-snapshots/models/project-snapshot.model';
 import type { EndpointPreview } from '../../shared/models/endpoint-preview.model';
 import { ConfirmDialogComponent } from '../../shared/ui/confirm-dialog/confirm-dialog.component';
 import { CreateProjectModalComponent } from '../../shared/ui/create-project-modal/create-project-modal.component';
@@ -41,6 +43,7 @@ import type {
   PaginationState,
   SidebarProjectPaginationState,
   SidebarProjectRow,
+  SnapshotHistoryState,
   WorkspaceNavId,
 } from './models/workspace-shell.model';
 
@@ -83,6 +86,7 @@ export class WorkspaceShellComponent {
   private readonly projectsRepository = inject(ProjectsRepository);
   private readonly endpointsRepository = inject(EndpointsRepository);
   private readonly globalConfigRepository = inject(GlobalConfigRepository);
+  private readonly projectSnapshotsRepository = inject(ProjectSnapshotsRepository);
   private readonly workspaceMembersRepository = inject(WorkspaceMembersRepository);
 
   protected readonly projects = signal<DashboardProject[]>([]);
@@ -180,6 +184,11 @@ export class WorkspaceShellComponent {
   protected readonly selectedEndpointId = signal<string | null>(null);
   protected readonly endpointMutationPending = signal(false);
   protected readonly endpointMutationError = signal<string | null>(null);
+  protected readonly snapshotHistory = signal<ProjectSnapshot[]>([]);
+  protected readonly snapshotHistoryState = signal<SnapshotHistoryState>({
+    loadedForProjectId: null,
+    latestSnapshotId: null,
+  });
 
   protected readonly selectedLog = signal<ApiLogEntry | null>(null);
 
@@ -387,6 +396,12 @@ export class WorkspaceShellComponent {
         void this.reloadEndpointList(projectId);
       }
     }
+    if (id === 'history') {
+      const projectId = this.selectedProjectId() || this.activeProject()?.id;
+      if (projectId) {
+        void this.loadSnapshotHistory(projectId);
+      }
+    }
     if (id !== 'endpoints') {
       this.selectedEndpointId.set(null);
       this.createEndpointFlowOpen.set(false);
@@ -464,6 +479,13 @@ export class WorkspaceShellComponent {
   }
 
   protected testAllEndpoints(): void {}
+
+  protected async createSnapshot(): Promise<void> {
+    if (!this.canMutateActiveWorkspace()) return;
+    const project = this.activeProject();
+    if (!project || this.endpointMutationPending()) return;
+    await this.createProjectSnapshot(project.id, project.name);
+  }
 
   protected exportConfig(): void {
     if (!this.canMutateActiveWorkspace()) return;
@@ -620,6 +642,9 @@ export class WorkspaceShellComponent {
       const refreshed = await this.projectsRepository.getProject(projectId);
       this.projects.update((projects) => projects.map((project) => (project.id === projectId ? refreshed : project)));
       await this.reloadWorkspaceMembers(refreshed.workspace.id);
+      if (this.activeNav() === 'history') {
+        await this.loadSnapshotHistory(projectId, true);
+      }
       await this.reloadEndpointList(projectId);
     } catch (error) {
       this.endpointMutationError.set(error instanceof Error ? error.message : 'Could not refresh project data.');
@@ -1008,6 +1033,62 @@ export class WorkspaceShellComponent {
       this.workspaceMembersError.set(error instanceof Error ? error.message : 'Could not remove workspace member.');
     } finally {
       this.workspaceMemberMutationPending.set(false);
+    }
+  }
+
+  protected async restoreSnapshot(snapshotId: string): Promise<void> {
+    if (!this.canMutateActiveWorkspace()) return;
+    const projectId = this.selectedProjectId() || this.activeProject()?.id;
+    if (!projectId || this.endpointMutationPending()) return;
+
+    this.endpointMutationPending.set(true);
+    this.endpointMutationError.set(null);
+
+    try {
+      const snapshot = await this.projectSnapshotsRepository.get(projectId, snapshotId);
+      const confirmed = window.confirm(`Restore snapshot “${snapshot.name}”? Live endpoints/config will be replaced.`);
+      if (!confirmed) return;
+
+      await this.projectSnapshotsRepository.restore(projectId, snapshotId);
+      await this.refreshProject(projectId);
+      await this.loadSnapshotHistory(projectId, true);
+    } catch (error) {
+      this.endpointMutationError.set(error instanceof Error ? error.message : 'Could not restore snapshot.');
+    } finally {
+      this.endpointMutationPending.set(false);
+    }
+  }
+
+  private async createProjectSnapshot(projectId: string, projectName: string): Promise<void> {
+    this.endpointMutationPending.set(true);
+    this.endpointMutationError.set(null);
+
+    try {
+      const timestamp = new Date().toISOString().slice(0, 16).replace('T', ' ');
+      await this.projectSnapshotsRepository.create(projectId, {
+        name: `${projectName} @ ${timestamp}`,
+      });
+      await this.loadSnapshotHistory(projectId, true);
+      await this.refreshProject(projectId);
+    } catch (error) {
+      this.endpointMutationError.set(error instanceof Error ? error.message : 'Could not create snapshot.');
+    } finally {
+      this.endpointMutationPending.set(false);
+    }
+  }
+
+  private async loadSnapshotHistory(projectId: string, force = false): Promise<void> {
+    if (!force && this.snapshotHistoryState().loadedForProjectId === projectId) return;
+
+    try {
+      const response = await this.projectSnapshotsRepository.list(projectId);
+      this.snapshotHistory.set(response.items);
+      this.snapshotHistoryState.set({
+        loadedForProjectId: projectId,
+        latestSnapshotId: response.items[0]?.id ?? null,
+      });
+    } catch (error) {
+      this.endpointMutationError.set(error instanceof Error ? error.message : 'Could not load snapshot history.');
     }
   }
 }

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.integration.spec.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.integration.spec.ts
@@ -10,6 +10,7 @@ import { LogsComponent } from '../logs/logs.component';
 import { ProjectsRepository } from '../main-dashboard/data-access/projects.repository';
 import { EndpointsRepository } from '../endpoints/data-access/endpoints.repository';
 import { GlobalConfigRepository } from '../global-config/data-access/global-config.repository';
+import { ProjectSnapshotsRepository } from '../project-snapshots/data-access/project-snapshots.repository';
 import { WorkspaceMembersRepository } from '../workspace-members/data-access/workspace-members.repository';
 import { WorkspaceShellComponent } from './workspace-shell.component';
 
@@ -104,6 +105,13 @@ describe('WorkspaceShellComponent integration', () => {
     removeMember: vi.fn(),
   };
 
+  const projectSnapshotsRepository = {
+    list: vi.fn(),
+    get: vi.fn(),
+    create: vi.fn(),
+    restore: vi.fn(),
+  };
+
   const authSession = {
     snapshot: signal({
       state: 'authenticated',
@@ -140,6 +148,10 @@ describe('WorkspaceShellComponent integration', () => {
     endpointsRepository.deleteEndpoint.mockReset();
     globalConfigRepository.getConfig.mockReset();
     globalConfigRepository.saveConfig.mockReset();
+    projectSnapshotsRepository.list.mockReset();
+    projectSnapshotsRepository.get.mockReset();
+    projectSnapshotsRepository.create.mockReset();
+    projectSnapshotsRepository.restore.mockReset();
     workspaceMembersRepository.listMembers.mockReset();
     workspaceMembersRepository.addMember.mockReset();
     workspaceMembersRepository.removeMember.mockReset();
@@ -151,6 +163,10 @@ describe('WorkspaceShellComponent integration', () => {
     authSession.canAccessProtectedRoutes.mockReset();
     authSession.handleProtectedApiError.mockReturnValue(false);
     authSession.canAccessProtectedRoutes.mockReturnValue(true);
+    projectSnapshotsRepository.list.mockResolvedValue({ items: [] });
+    projectSnapshotsRepository.get.mockResolvedValue(null);
+    projectSnapshotsRepository.create.mockResolvedValue(null);
+    projectSnapshotsRepository.restore.mockResolvedValue(undefined);
     authSession.snapshot.set({
       state: 'authenticated',
       userId: 'user-1',
@@ -260,6 +276,7 @@ describe('WorkspaceShellComponent integration', () => {
         { provide: ApiClient, useValue: api },
         { provide: EndpointsRepository, useValue: endpointsRepository },
         { provide: GlobalConfigRepository, useValue: globalConfigRepository },
+        { provide: ProjectSnapshotsRepository, useValue: projectSnapshotsRepository },
         { provide: WorkspaceMembersRepository, useValue: workspaceMembersRepository },
         { provide: FrontendAuthSessionService, useValue: authSession },
       ],

--- a/apps/web/src/app/shared/http/api.types.ts
+++ b/apps/web/src/app/shared/http/api.types.ts
@@ -183,6 +183,77 @@ export interface GlobalConfigDto {
 
 export type SaveGlobalConfigDto = Omit<GlobalConfigDto, 'projectId'>;
 
+export interface ProjectSnapshotActorDto {
+  userId: string;
+  email: string | null;
+  displayName: string | null;
+}
+
+export interface ProjectSnapshotPayloadEndpointConfigDto {
+  latencyMode: 'fixed' | 'range';
+  fixedDelayMs: number;
+  minDelayMs: number;
+  maxDelayMs: number;
+  errorRate: number;
+  useScenarioWeights: boolean;
+}
+
+export interface ProjectSnapshotPayloadScenarioDto {
+  name: string;
+  type: 'success' | 'error' | 'timeout' | 'empty';
+  statusCode: number;
+  body: unknown;
+  delayMs: number;
+  weight: number;
+}
+
+export interface ProjectSnapshotPayloadEndpointDto {
+  method: string;
+  path: string;
+  description: string;
+  statusCode: number;
+  responseBody: unknown;
+  endpointConfig: ProjectSnapshotPayloadEndpointConfigDto;
+  scenarios: ProjectSnapshotPayloadScenarioDto[];
+}
+
+export interface ProjectSnapshotPayloadDto {
+  project: {
+    id: string;
+    slug: string;
+    name: string;
+    description: string;
+  };
+  globalConfig: GlobalConfigDto;
+  endpoints: ProjectSnapshotPayloadEndpointDto[];
+}
+
+export interface ProjectSnapshotDto {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  createdBy: ProjectSnapshotActorDto;
+}
+
+export interface ProjectSnapshotListDto {
+  items: ProjectSnapshotDto[];
+}
+
+export interface ProjectSnapshotDetailDto extends ProjectSnapshotDto {
+  payload: ProjectSnapshotPayloadDto;
+}
+
+export interface CreateProjectSnapshotDto {
+  name: string;
+  description?: string;
+}
+
+export interface RestoreProjectSnapshotResponseDto {
+  restoredSnapshotId: string;
+}
+
 export interface ApiLogDto {
   id: string;
   projectId: string;
@@ -214,8 +285,14 @@ export interface ApiLogListDto {
   serverTime: string;
 }
 
-export type ApiAuditEventResourceTypeDto = 'project' | 'endpoint' | 'scenario' | 'global-config' | 'endpoint-config';
-export type ApiAuditEventActionDto = 'created' | 'updated' | 'deleted';
+export type ApiAuditEventResourceTypeDto =
+  | 'project'
+  | 'endpoint'
+  | 'scenario'
+  | 'global-config'
+  | 'endpoint-config'
+  | 'snapshot';
+export type ApiAuditEventActionDto = 'created' | 'updated' | 'deleted' | 'restored';
 
 export interface ApiAuditActorDto {
   userId: string;


### PR DESCRIPTION
Closes #55

## Summary
- add durable project snapshots with backend create/list/detail/restore APIs and explicit snapshot audit events
- wire minimal snapshot create/restore flows into audit history and workspace management surfaces
- cover the slice with focused backend/frontend tests plus clean backend/frontend type checks for the changed areas

## Changes
| File | Change |
|------|--------|
| `apps/backend/prisma/schema.prisma` | adds `ProjectSnapshot` persistence model and project relation |
| `apps/backend/src/management/project-snapshots/*` | implements snapshot schemas, service logic, router, and focused backend tests |
| `apps/backend/src/management/audit-events/schema.ts` | widens audit resource/action unions for snapshot events |
| `apps/web/src/app/features/project-snapshots/*` | adds frontend snapshot models, mapper, repository, and focused tests |
| `apps/web/src/app/features/audit-history/*` | renders snapshot-friendly audit labels and restore CTA behavior |
| `apps/web/src/app/features/workspace-shell/*` | wires create/restore snapshot flows into workspace shell history state |
| `apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/*` | adds create snapshot quick action and read-only gating |
| `apps/web/src/app/shared/http/api.types.ts` | adds snapshot DTOs and widened audit contracts |

## Test Plan
- [x] `pnpm --dir apps/backend test -- src/management/project-snapshots/service.test.ts src/__tests__/project-snapshots.integration.test.ts`
- [x] `pnpm --dir apps/backend exec tsc --noEmit -p tsconfig.json`
- [x] `pnpm --dir apps/web test -- src/app/features/project-snapshots/adapters/project-snapshot-api.mapper.spec.ts src/app/features/project-snapshots/data-access/project-snapshots.repository.spec.ts src/app/features/workspace-shell/workspace-shell.audit-history.integration.spec.ts src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.spec.ts src/app/features/audit-history/audit-history.component.spec.ts`
- [x] `pnpm --dir apps/web exec tsc --project tsconfig.spec.json --noEmit`
- [x] `pnpm exec eslint apps/backend/src/__tests__/project-snapshots.integration.test.ts apps/web/src/app/features/audit-history/audit-history.component.spec.ts`

## Checklist
- [x] Linked approved issue `#55`
- [x] Added exactly one `type:*` label
- [x] Conventional commit used
- [x] No `Co-Authored-By` trailers