### PR TITLE
feat(ai): add provider fallback abstraction

### DIFF
--- a/apps/backend/src/__tests__/app.integration.test.ts
+++ b/apps/backend/src/__tests__/app.integration.test.ts
@@ -4,6 +4,7 @@ import type { Express } from 'express';
 import { resetRateLimitStoreForTests } from '../mock-server/rate-limit.js';
 
 const openaiCreateMock = vi.fn();
+const openAiClientConfigs: Array<Record<string, unknown> | undefined> = [];
 const runtimeRateLimitBuckets = new Map<string, { requestCount: number }>();
 
 const prismaMock = {
@@ -90,6 +91,10 @@ vi.mock('../lib/prisma.js', () => ({
 
 vi.mock('openai', () => ({
   default: class MockOpenAI {
+    public constructor(config?: Record<string, unknown>) {
+      openAiClientConfigs.push(config);
+    }
+
     public chat = {
       completions: {
         create: openaiCreateMock,
@@ -211,6 +216,7 @@ describe('app integration', () => {
     resetNestedMocks(prismaMock.runtimeRateLimitBucket);
     prismaMock.$transaction.mockReset();
     openaiCreateMock.mockReset();
+    openAiClientConfigs.length = 0;
     resetRateLimitStoreForTests();
     runtimeRateLimitBuckets.clear();
     prismaMock.runtimeRateLimitBucket.upsert.mockImplementation(
@@ -1485,6 +1491,103 @@ describe('app integration', () => {
     expect(prismaMock.scenario.createMany).not.toHaveBeenCalled();
   });
 
+  it('POST /api/v1/projects/:projectId/endpoints/ai-generate usa fallback cuando falla la ejecución del primario y persiste el endpoint', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+    prismaMock.endpoint.findFirst.mockResolvedValueOnce(null);
+
+    const { env } = await import('../config/env.js');
+    const originalPrimary = env.AI_PRIMARY_PROVIDER;
+    const originalFallback = env.AI_FALLBACK_PROVIDER;
+    const originalCompatKey = env.AI_COMPAT_API_KEY;
+    const originalCompatModel = env.AI_COMPAT_MODEL;
+    const originalCompatBaseUrl = env.AI_COMPAT_BASE_URL;
+
+    env.AI_PRIMARY_PROVIDER = 'openai';
+    env.AI_FALLBACK_PROVIDER = 'compat';
+    env.AI_COMPAT_API_KEY = 'compat-key';
+    env.AI_COMPAT_MODEL = 'compat-model';
+    env.AI_COMPAT_BASE_URL = 'https://compat.example.com/v1';
+
+    openaiCreateMock.mockRejectedValueOnce(new Error('primary unavailable')).mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              method: 'POST',
+              path: '/users',
+              description: 'Create user',
+              statusCode: 201,
+              responseBody: { id: 'u1' },
+              scenarios: [
+                {
+                  name: 'success',
+                  type: 'success',
+                  statusCode: 201,
+                  body: { id: 'u1' },
+                  delayMs: 0,
+                  weight: 1,
+                },
+              ],
+            }),
+          },
+        },
+      ],
+    });
+
+    const tx = {
+      endpoint: {
+        create: vi.fn().mockResolvedValue({ id: 'e-ai-fallback-1' }),
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: 'e-ai-fallback-1',
+          method: 'POST',
+          path: '/users',
+          endpointConfig: { endpointId: 'e-ai-fallback-1' },
+          scenarios: [{ id: 's-ai-fallback-1', type: 'success' }],
+        }),
+      },
+      endpointConfig: {
+        create: vi.fn().mockResolvedValue({ id: 'cfg-ai-fallback-1' }),
+      },
+      scenario: {
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementationOnce(async (callback) => callback(tx));
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/projects/p1/endpoints/ai-generate')
+        .set(authHeaders())
+        .send({ prompt: 'Generate endpoint for creating users using fallback execution' });
+
+      expect(response.status).toBe(201);
+      expect(response.body).toMatchObject({
+        id: 'e-ai-fallback-1',
+        method: 'POST',
+        path: '/users',
+      });
+      expect(tx.endpoint.create).toHaveBeenCalled();
+      expect(tx.scenario.createMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: [expect.objectContaining({ type: 'success' })],
+        })
+      );
+      expect(openAiClientConfigs).toContainEqual(
+        expect.objectContaining({
+          apiKey: 'compat-key',
+          baseURL: 'https://compat.example.com/v1',
+        })
+      );
+    } finally {
+      env.AI_PRIMARY_PROVIDER = originalPrimary;
+      env.AI_FALLBACK_PROVIDER = originalFallback;
+      env.AI_COMPAT_API_KEY = originalCompatKey;
+      env.AI_COMPAT_MODEL = originalCompatModel;
+      env.AI_COMPAT_BASE_URL = originalCompatBaseUrl;
+    }
+  });
+
   it('POST /api/v1/projects/:projectId/endpoints/ai-preview devuelve draft normalizado sin persistir', async () => {
     prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
     openaiCreateMock.mockResolvedValueOnce({
@@ -1629,5 +1732,163 @@ describe('app integration', () => {
       code: 'AI_INVALID_OUTPUT',
       retryable: true,
     });
+  });
+
+  it('POST /api/v1/projects/:projectId/endpoints/ai-preview usa fallback cuando falla la ejecución del primario', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+    const { env } = await import('../config/env.js');
+    const originalPrimary = env.AI_PRIMARY_PROVIDER;
+    const originalFallback = env.AI_FALLBACK_PROVIDER;
+    const originalCompatKey = env.AI_COMPAT_API_KEY;
+    const originalCompatModel = env.AI_COMPAT_MODEL;
+    const originalCompatBaseUrl = env.AI_COMPAT_BASE_URL;
+
+    env.AI_PRIMARY_PROVIDER = 'openai';
+    env.AI_FALLBACK_PROVIDER = 'compat';
+    env.AI_COMPAT_API_KEY = 'compat-key';
+    env.AI_COMPAT_MODEL = 'compat-model';
+    env.AI_COMPAT_BASE_URL = 'https://compat.example.com/v1';
+
+    openaiCreateMock
+      .mockRejectedValueOnce(new Error('upstream unavailable'))
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                method: 'POST',
+                path: '/users',
+                description: 'Create user',
+                statusCode: 201,
+                responseBody: { id: 'u1' },
+                scenarios: [
+                  {
+                    name: 'success',
+                    type: 'success',
+                    statusCode: 201,
+                    body: { id: 'u1' },
+                    delayMs: 0,
+                    weight: 1,
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      });
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/projects/p1/endpoints/ai-preview')
+        .set(authHeaders())
+        .send({ prompt: 'Generate a user creation endpoint preview using fallback execution' });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toMatchObject({ method: 'POST', path: '/users' });
+      expect(openaiCreateMock).toHaveBeenCalledTimes(2);
+    } finally {
+      env.AI_PRIMARY_PROVIDER = originalPrimary;
+      env.AI_FALLBACK_PROVIDER = originalFallback;
+      env.AI_COMPAT_API_KEY = originalCompatKey;
+      env.AI_COMPAT_MODEL = originalCompatModel;
+      env.AI_COMPAT_BASE_URL = originalCompatBaseUrl;
+    }
+  });
+
+  it('POST /api/v1/projects/:projectId/endpoints/ai-preview no usa fallback cuando el primario devuelve salida inválida', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+    const { env } = await import('../config/env.js');
+    const originalPrimary = env.AI_PRIMARY_PROVIDER;
+    const originalFallback = env.AI_FALLBACK_PROVIDER;
+    const originalCompatKey = env.AI_COMPAT_API_KEY;
+    const originalCompatModel = env.AI_COMPAT_MODEL;
+    const originalCompatBaseUrl = env.AI_COMPAT_BASE_URL;
+
+    env.AI_PRIMARY_PROVIDER = 'openai';
+    env.AI_FALLBACK_PROVIDER = 'compat';
+    env.AI_COMPAT_API_KEY = 'compat-key';
+    env.AI_COMPAT_MODEL = 'compat-model';
+    env.AI_COMPAT_BASE_URL = 'https://compat.example.com/v1';
+
+    openaiCreateMock.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              method: 'GET',
+              path: '/users',
+              description: 'Broken payload',
+              statusCode: 200,
+              responseBody: [],
+              scenarios: [],
+            }),
+          },
+        },
+      ],
+    });
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/projects/p1/endpoints/ai-preview')
+        .set(authHeaders())
+        .send({
+          prompt:
+            'Generate a users endpoint preview with malformed primary output and fallback configured',
+        });
+
+      expect(response.status).toBe(422);
+      expect(response.body).toMatchObject({
+        error: 'AI returned invalid output',
+        code: 'AI_INVALID_OUTPUT',
+      });
+      expect(openaiCreateMock).toHaveBeenCalledTimes(2);
+    } finally {
+      env.AI_PRIMARY_PROVIDER = originalPrimary;
+      env.AI_FALLBACK_PROVIDER = originalFallback;
+      env.AI_COMPAT_API_KEY = originalCompatKey;
+      env.AI_COMPAT_MODEL = originalCompatModel;
+      env.AI_COMPAT_BASE_URL = originalCompatBaseUrl;
+    }
+  });
+
+  it('POST /api/v1/projects/:projectId/endpoints/ai-preview conserva error determinístico cuando se agota la cadena', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+    const { env } = await import('../config/env.js');
+    const originalPrimary = env.AI_PRIMARY_PROVIDER;
+    const originalFallback = env.AI_FALLBACK_PROVIDER;
+    const originalCompatKey = env.AI_COMPAT_API_KEY;
+    const originalCompatModel = env.AI_COMPAT_MODEL;
+    const originalCompatBaseUrl = env.AI_COMPAT_BASE_URL;
+
+    env.AI_PRIMARY_PROVIDER = 'openai';
+    env.AI_FALLBACK_PROVIDER = 'compat';
+    env.AI_COMPAT_API_KEY = 'compat-key';
+    env.AI_COMPAT_MODEL = 'compat-model';
+    env.AI_COMPAT_BASE_URL = 'https://compat.example.com/v1';
+
+    openaiCreateMock
+      .mockRejectedValueOnce(new Error('primary unavailable'))
+      .mockRejectedValueOnce(new Error('fallback unavailable'));
+
+    try {
+      const response = await request(app)
+        .post('/api/v1/projects/p1/endpoints/ai-preview')
+        .set(authHeaders())
+        .send({ prompt: 'Generate a users endpoint preview with both providers unavailable' });
+
+      expect(response.status).toBe(503);
+      expect(response.body).toMatchObject({
+        error: 'AI is unavailable right now',
+        code: 'AI_UNAVAILABLE',
+        retryable: true,
+      });
+      expect(openaiCreateMock).toHaveBeenCalledTimes(2);
+    } finally {
+      env.AI_PRIMARY_PROVIDER = originalPrimary;
+      env.AI_FALLBACK_PROVIDER = originalFallback;
+      env.AI_COMPAT_API_KEY = originalCompatKey;
+      env.AI_COMPAT_MODEL = originalCompatModel;
+      env.AI_COMPAT_BASE_URL = originalCompatBaseUrl;
+    }
   });
 });

--- a/apps/backend/src/config/env.test.ts
+++ b/apps/backend/src/config/env.test.ts
@@ -36,6 +36,42 @@ describe('parseEnv', () => {
     expect(parsed.OPENAI_MODEL).toBe('gpt-4.1-mini');
   });
 
+  it('resuelve OpenAI como provider principal por default para mantener compatibilidad', () => {
+    const parsed = parseEnv({
+      ...baseEnv,
+      OPENAI_API_KEY: 'test-key',
+    });
+
+    expect(parsed.AI_PRIMARY_PROVIDER).toBe('openai');
+    expect(parsed.AI_FALLBACK_PROVIDER).toBeUndefined();
+  });
+
+  it('acepta provider principal y fallback explícitos junto con credenciales compat', () => {
+    const parsed = parseEnv({
+      ...baseEnv,
+      AI_PRIMARY_PROVIDER: 'compat',
+      AI_FALLBACK_PROVIDER: 'openai',
+      AI_COMPAT_API_KEY: 'compat-key',
+      AI_COMPAT_MODEL: 'llama-3.1-70b',
+      AI_COMPAT_BASE_URL: 'https://compat.example.com/v1',
+    });
+
+    expect(parsed.AI_PRIMARY_PROVIDER).toBe('compat');
+    expect(parsed.AI_FALLBACK_PROVIDER).toBe('openai');
+    expect(parsed.AI_COMPAT_API_KEY).toBe('compat-key');
+    expect(parsed.AI_COMPAT_MODEL).toBe('llama-3.1-70b');
+    expect(parsed.AI_COMPAT_BASE_URL).toBe('https://compat.example.com/v1');
+  });
+
+  it('rechaza nombres de provider inválidos', () => {
+    expect(() =>
+      parseEnv({
+        ...baseEnv,
+        AI_PRIMARY_PROVIDER: 'anthropic',
+      })
+    ).toThrowError();
+  });
+
   it('normaliza CORS_ALLOWED_ORIGINS como lista separada por comas', () => {
     const parsed = parseEnv({
       ...baseEnv,
@@ -48,5 +84,17 @@ describe('parseEnv', () => {
       'https://admin.example.com',
       'http://localhost:4200',
     ]);
+  });
+
+  it('normaliza strings vacíos para fallback y modelo compat', () => {
+    const parsed = parseEnv({
+      ...baseEnv,
+      AI_PRIMARY_PROVIDER: 'openai',
+      AI_FALLBACK_PROVIDER: '   ',
+      AI_COMPAT_MODEL: '   ',
+    });
+
+    expect(parsed.AI_FALLBACK_PROVIDER).toBeUndefined();
+    expect(parsed.AI_COMPAT_MODEL).toBeUndefined();
   });
 });

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -28,6 +28,19 @@ const defaultedNonEmptyString = (fallback: string) =>
     return trimmed === '' ? undefined : trimmed;
   }, z.string().min(1).default(fallback));
 
+const optionalProviderName = z.preprocess(
+  (value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmed = value.trim().toLowerCase();
+
+    return trimmed === '' ? undefined : trimmed;
+  },
+  z.enum(['openai', 'compat']).optional()
+);
+
 const optionalStringArray = z.preprocess(
   (value) => {
     if (typeof value !== 'string') {
@@ -48,6 +61,30 @@ const envSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
   PORT: z.coerce.number().default(3000),
   DATABASE_URL: z.string().min(1),
+  AI_PRIMARY_PROVIDER: z.preprocess(
+    (value) => {
+      if (typeof value !== 'string') {
+        return value;
+      }
+
+      const trimmed = value.trim().toLowerCase();
+
+      return trimmed === '' ? undefined : trimmed;
+    },
+    z.enum(['openai', 'compat']).default('openai')
+  ),
+  AI_FALLBACK_PROVIDER: optionalProviderName,
+  AI_COMPAT_API_KEY: optionalNonEmptyString,
+  AI_COMPAT_MODEL: optionalNonEmptyString,
+  AI_COMPAT_BASE_URL: z.preprocess((value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed === '' ? undefined : trimmed;
+  }, z.string().url().optional()),
   OPENAI_API_KEY: optionalNonEmptyString,
   OPENAI_MODEL: defaultedNonEmptyString('gpt-4.1-mini'),
   MOCK_BASE_URL: z.string().url().default('http://localhost:3000/mock'),

--- a/apps/backend/src/management/ai/provider.test.ts
+++ b/apps/backend/src/management/ai/provider.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAiProviderChain } from './provider.js';
+import { createCompatAiProvider } from './providers/compat.js';
+import { createOpenAiProvider } from './providers/openai.js';
+
+describe('resolveAiProviderChain', () => {
+  it('devuelve la cadena primaria y fallback en orden', () => {
+    const chain = resolveAiProviderChain({
+      AI_PRIMARY_PROVIDER: 'openai',
+      AI_FALLBACK_PROVIDER: 'compat',
+    });
+
+    expect(chain).toEqual(['openai', 'compat']);
+  });
+
+  it('deduplica fallback repetido para no ejecutar dos veces el mismo provider', () => {
+    const chain = resolveAiProviderChain({
+      AI_PRIMARY_PROVIDER: 'openai',
+      AI_FALLBACK_PROVIDER: 'openai',
+    });
+
+    expect(chain).toEqual(['openai']);
+  });
+});
+
+describe('provider adapters', () => {
+  it('reporta missing-config para OpenAI cuando falta la API key', async () => {
+    const provider = createOpenAiProvider(
+      {
+        OPENAI_API_KEY: undefined,
+        OPENAI_MODEL: 'gpt-4.1-mini',
+      },
+      { systemPrompt: 'system' }
+    );
+
+    await expect(provider.generateJson('prompt')).rejects.toMatchObject({
+      kind: 'missing-config',
+      details: 'OPENAI_API_KEY is not configured',
+      provider: 'openai',
+    });
+  });
+
+  it('reporta missing-config para compat cuando faltan credenciales requeridas', async () => {
+    const provider = createCompatAiProvider(
+      {
+        AI_COMPAT_API_KEY: 'compat-key',
+        AI_COMPAT_MODEL: undefined,
+        AI_COMPAT_BASE_URL: undefined,
+      },
+      { systemPrompt: 'system' }
+    );
+
+    await expect(provider.generateJson('prompt')).rejects.toMatchObject({
+      kind: 'missing-config',
+      provider: 'compat',
+    });
+  });
+});

--- a/apps/backend/src/management/ai/provider.ts
+++ b/apps/backend/src/management/ai/provider.ts
@@ -1,0 +1,29 @@
+import type { Env } from '../../config/env.js';
+
+export type AiProviderName = 'openai' | 'compat';
+
+export interface AiProvider {
+  name: AiProviderName;
+  generateJson(prompt: string): Promise<string>;
+}
+
+export class AiProviderExecutionError extends Error {
+  constructor(
+    public readonly provider: AiProviderName,
+    public readonly kind: 'missing-config' | 'timeout' | 'unavailable',
+    public readonly details?: string
+  ) {
+    super(kind);
+    this.name = 'AiProviderExecutionError';
+  }
+}
+
+type AiProviderChainConfig = Pick<Env, 'AI_PRIMARY_PROVIDER' | 'AI_FALLBACK_PROVIDER'>;
+
+export function resolveAiProviderChain(config: AiProviderChainConfig): AiProviderName[] {
+  const orderedProviders = [config.AI_PRIMARY_PROVIDER, config.AI_FALLBACK_PROVIDER].filter(
+    (provider): provider is AiProviderName => provider !== undefined
+  );
+
+  return orderedProviders.filter((provider, index) => orderedProviders.indexOf(provider) === index);
+}

--- a/apps/backend/src/management/ai/providers/compat.ts
+++ b/apps/backend/src/management/ai/providers/compat.ts
@@ -1,0 +1,102 @@
+import OpenAI from 'openai';
+import type { Env } from '../../../config/env.js';
+import { AiProviderExecutionError, type AiProvider } from '../provider.js';
+
+type CompatConfig = Pick<Env, 'AI_COMPAT_API_KEY' | 'AI_COMPAT_MODEL' | 'AI_COMPAT_BASE_URL'>;
+
+async function requestJsonCompletion(
+  client: OpenAI,
+  model: string,
+  systemPrompt: string,
+  prompt: string,
+  timeoutMs = 30_000
+): Promise<string> {
+  const completionPromise = client.chat.completions.create({
+    model,
+    temperature: 0.2,
+    response_format: { type: 'json_object' },
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: prompt },
+    ],
+  });
+
+  let timeoutHandle: NodeJS.Timeout | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new AiProviderExecutionError('compat', 'timeout'));
+    }, timeoutMs);
+  });
+
+  try {
+    const completion = await Promise.race([completionPromise, timeoutPromise]);
+
+    return completion.choices[0]?.message?.content?.trim() ?? '';
+  } catch (error) {
+    if (error instanceof AiProviderExecutionError) {
+      throw error;
+    }
+
+    const errorCode =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+
+    if (errorCode === 'ETIMEDOUT') {
+      throw new AiProviderExecutionError('compat', 'timeout');
+    }
+
+    throw new AiProviderExecutionError('compat', 'unavailable');
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+export function createCompatAiProvider(
+  config: CompatConfig,
+  options: { systemPrompt: string; timeoutMs?: number }
+): AiProvider {
+  return {
+    name: 'compat',
+    async generateJson(prompt: string) {
+      const missing: string[] = [];
+      const apiKey = config.AI_COMPAT_API_KEY;
+      const model = config.AI_COMPAT_MODEL;
+      const baseURL = config.AI_COMPAT_BASE_URL;
+
+      if (!apiKey) {
+        missing.push('AI_COMPAT_API_KEY');
+      }
+
+      if (!model) {
+        missing.push('AI_COMPAT_MODEL');
+      }
+
+      if (!baseURL) {
+        missing.push('AI_COMPAT_BASE_URL');
+      }
+
+      if (missing.length > 0) {
+        throw new AiProviderExecutionError(
+          'compat',
+          'missing-config',
+          `${missing.join(', ')} ${missing.length === 1 ? 'is' : 'are'} not configured`
+        );
+      }
+
+      if (!apiKey || !model || !baseURL) {
+        throw new AiProviderExecutionError('compat', 'missing-config');
+      }
+
+      const client = new OpenAI({
+        apiKey,
+        baseURL,
+      });
+
+      return requestJsonCompletion(client, model, options.systemPrompt, prompt, options.timeoutMs);
+    },
+  };
+}

--- a/apps/backend/src/management/ai/providers/openai.ts
+++ b/apps/backend/src/management/ai/providers/openai.ts
@@ -1,0 +1,86 @@
+import OpenAI from 'openai';
+import type { Env } from '../../../config/env.js';
+import { AiProviderExecutionError, type AiProvider } from '../provider.js';
+
+type OpenAiConfig = Pick<Env, 'OPENAI_API_KEY' | 'OPENAI_MODEL'>;
+
+async function requestJsonCompletion(
+  provider: AiProvider['name'],
+  client: OpenAI,
+  model: string,
+  systemPrompt: string,
+  prompt: string,
+  timeoutMs = 30_000
+): Promise<string> {
+  const completionPromise = client.chat.completions.create({
+    model,
+    temperature: 0.2,
+    response_format: { type: 'json_object' },
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: prompt },
+    ],
+  });
+
+  let timeoutHandle: NodeJS.Timeout | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => {
+      reject(new AiProviderExecutionError(provider, 'timeout'));
+    }, timeoutMs);
+  });
+
+  try {
+    const completion = await Promise.race([completionPromise, timeoutPromise]);
+
+    return completion.choices[0]?.message?.content?.trim() ?? '';
+  } catch (error) {
+    if (error instanceof AiProviderExecutionError) {
+      throw error;
+    }
+
+    const errorCode =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+
+    if (errorCode === 'ETIMEDOUT') {
+      throw new AiProviderExecutionError(provider, 'timeout');
+    }
+
+    throw new AiProviderExecutionError(provider, 'unavailable');
+  } finally {
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+export function createOpenAiProvider(
+  config: OpenAiConfig,
+  options: { systemPrompt: string; timeoutMs?: number }
+): AiProvider {
+  return {
+    name: 'openai',
+    async generateJson(prompt: string) {
+      if (!config.OPENAI_API_KEY) {
+        throw new AiProviderExecutionError(
+          'openai',
+          'missing-config',
+          'OPENAI_API_KEY is not configured'
+        );
+      }
+
+      const client = new OpenAI({ apiKey: config.OPENAI_API_KEY });
+
+      return requestJsonCompletion(
+        'openai',
+        client,
+        config.OPENAI_MODEL,
+        options.systemPrompt,
+        prompt,
+        options.timeoutMs
+      );
+    },
+  };
+}

--- a/apps/backend/src/management/ai/service.test.ts
+++ b/apps/backend/src/management/ai/service.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { normalizeAiDraft } from './normalize-draft.js';
+import {
+  AiProviderExecutionError,
+  createNormalizedDraftWithFallback,
+  type AiProvider,
+} from './service.js';
 
 describe('normalizeAiDraft', () => {
   it('normaliza method/path y expone locks para preview/persist', () => {
@@ -81,5 +86,123 @@ describe('normalizeAiDraft', () => {
         weight: 1,
       },
     ]);
+  });
+});
+
+describe('createNormalizedDraftWithFallback', () => {
+  it('usa el provider primario cuando ejecuta correctamente', async () => {
+    const fallback = {
+      name: 'compat',
+      generateJson: async () => JSON.stringify({ invalid: true }),
+    } satisfies AiProvider;
+    const providers = [
+      {
+        name: 'openai',
+        generateJson: async () =>
+          JSON.stringify({
+            method: 'GET',
+            path: '/users',
+            description: 'List users',
+            statusCode: 200,
+            responseBody: [],
+            scenarios: [
+              {
+                name: 'success',
+                type: 'success',
+                statusCode: 200,
+                body: [],
+                delayMs: 0,
+                weight: 1,
+              },
+            ],
+          }),
+      },
+      fallback,
+    ] satisfies AiProvider[];
+
+    const draft = await createNormalizedDraftWithFallback('prompt', providers);
+
+    expect(draft.method).toBe('GET');
+    expect(draft.path).toBe('/users');
+  });
+
+  it('usa fallback solo ante error de ejecución del provider primario', async () => {
+    const providers = [
+      {
+        name: 'openai',
+        generateJson: async () => {
+          throw new AiProviderExecutionError('openai', 'timeout');
+        },
+      },
+      {
+        name: 'compat',
+        generateJson: async () =>
+          JSON.stringify({
+            method: 'POST',
+            path: '/users',
+            description: 'Create user',
+            statusCode: 201,
+            responseBody: { id: 'u1' },
+            scenarios: [
+              {
+                name: 'success',
+                type: 'success',
+                statusCode: 201,
+                body: { id: 'u1' },
+                delayMs: 0,
+                weight: 1,
+              },
+            ],
+          }),
+      },
+    ] satisfies AiProvider[];
+
+    const draft = await createNormalizedDraftWithFallback('prompt', providers);
+
+    expect(draft.method).toBe('POST');
+    expect(draft.path).toBe('/users');
+  });
+
+  it('no usa fallback cuando la salida del primario es inválida', async () => {
+    const providers = [
+      {
+        name: 'openai',
+        generateJson: async () => JSON.stringify({ method: 'GET', scenarios: [] }),
+      },
+      {
+        name: 'compat',
+        generateJson: async () =>
+          JSON.stringify({
+            method: 'POST',
+            path: '/users',
+            description: 'Should not be used',
+            statusCode: 201,
+            responseBody: { id: 'u1' },
+            scenarios: [
+              {
+                name: 'success',
+                type: 'success',
+                statusCode: 201,
+                body: { id: 'u1' },
+                delayMs: 0,
+                weight: 1,
+              },
+            ],
+          }),
+      },
+    ] satisfies AiProvider[];
+
+    await expect(createNormalizedDraftWithFallback('prompt', providers)).rejects.toMatchObject({
+      options: { code: 'AI_INVALID_OUTPUT' },
+    });
+  });
+
+  it('falla de forma determinística cuando no hay providers activos', async () => {
+    await expect(createNormalizedDraftWithFallback('prompt', [])).rejects.toMatchObject({
+      options: {
+        code: 'AI_UNAVAILABLE',
+        retryable: false,
+      },
+    });
   });
 });

--- a/apps/backend/src/management/ai/service.ts
+++ b/apps/backend/src/management/ai/service.ts
@@ -1,4 +1,3 @@
-import { authorizeProjectAccess } from '../../auth/authorization.js';
 import type { AuthenticatedActor } from '../../auth/types.js';
 import type { Env } from '../../config/env.js';
 import { toPrismaJson } from '../../lib/prisma-json.js';
@@ -143,6 +142,11 @@ function mapProviderExecutionError(error: AiProviderExecutionError): AppError {
   return createAiUnavailableError();
 }
 
+async function authorizeAiProjectMutation(actor: AuthenticatedActor, projectId: string) {
+  const { authorizeProjectAccess } = await import('../../auth/authorization.js');
+  await authorizeProjectAccess(actor, projectId, 'mutate');
+}
+
 export async function createNormalizedDraftWithFallback(
   prompt: string,
   providers?: AiProvider[]
@@ -262,7 +266,7 @@ export async function generateEndpointPreview(
   projectId: string,
   prompt: string
 ) {
-  await authorizeProjectAccess(actor, projectId, 'mutate');
+  await authorizeAiProjectMutation(actor, projectId);
 
   return generateNormalizedDraft(prompt);
 }
@@ -272,7 +276,7 @@ export async function generateEndpointWithAi(
   projectId: string,
   prompt: string
 ) {
-  await authorizeProjectAccess(actor, projectId, 'mutate');
+  await authorizeAiProjectMutation(actor, projectId);
 
   const previewDraft = await generateNormalizedDraft(prompt);
   return persistGeneratedEndpoint(projectId, toPersistedDraft(previewDraft));

--- a/apps/backend/src/management/ai/service.ts
+++ b/apps/backend/src/management/ai/service.ts
@@ -1,8 +1,7 @@
 import { authorizeProjectAccess } from '../../auth/authorization.js';
 import type { AuthenticatedActor } from '../../auth/types.js';
-import { env } from '../../config/env.js';
+import type { Env } from '../../config/env.js';
 import { toPrismaJson } from '../../lib/prisma-json.js';
-import { prisma } from '../../lib/prisma.js';
 import { AppError } from '../../middleware/error-handler.js';
 import { normalizeAiDraft } from './normalize-draft.js';
 import { AiProviderExecutionError, resolveAiProviderChain, type AiProvider } from './provider.js';
@@ -115,7 +114,14 @@ function parseAiCompletion(rawContent: string): AiRawGeneratedEndpointInput {
   return parsed.data;
 }
 
-function buildAiProviders(): AiProvider[] {
+async function getEnv(): Promise<Env> {
+  const { env } = await import('../../config/env.js');
+  return env;
+}
+
+async function buildAiProviders(): Promise<AiProvider[]> {
+  const env = await getEnv();
+
   return resolveAiProviderChain(env).map((providerName) => {
     if (providerName === 'compat') {
       return createCompatAiProvider(env, { systemPrompt: SYSTEM_PROMPT });
@@ -139,15 +145,17 @@ function mapProviderExecutionError(error: AiProviderExecutionError): AppError {
 
 export async function createNormalizedDraftWithFallback(
   prompt: string,
-  providers: AiProvider[] = buildAiProviders()
+  providers?: AiProvider[]
 ): Promise<AiPreviewResponseInput> {
-  if (providers.length === 0) {
+  const activeProviders = providers ?? (await buildAiProviders());
+
+  if (activeProviders.length === 0) {
     throw createAiMissingConfigError('No AI providers are configured');
   }
 
   let lastExecutionError: AiProviderExecutionError | null = null;
 
-  for (const provider of providers) {
+  for (const provider of activeProviders) {
     for (let attempt = 0; attempt < 2; attempt += 1) {
       try {
         const generated = parseAiCompletion(await provider.generateJson(prompt));
@@ -190,6 +198,8 @@ function toPersistedDraft(previewDraft: AiPreviewResponseInput): AiNormalizedDra
 }
 
 async function persistGeneratedEndpoint(projectId: string, generated: AiNormalizedDraftInput) {
+  const { prisma } = await import('../../lib/prisma.js');
+
   const duplicate = await prisma.endpoint.findFirst({
     where: {
       projectId,

--- a/apps/backend/src/management/ai/service.ts
+++ b/apps/backend/src/management/ai/service.ts
@@ -1,11 +1,13 @@
 import { authorizeProjectAccess } from '../../auth/authorization.js';
 import type { AuthenticatedActor } from '../../auth/types.js';
-import OpenAI from 'openai';
 import { env } from '../../config/env.js';
 import { toPrismaJson } from '../../lib/prisma-json.js';
 import { prisma } from '../../lib/prisma.js';
 import { AppError } from '../../middleware/error-handler.js';
 import { normalizeAiDraft } from './normalize-draft.js';
+import { AiProviderExecutionError, resolveAiProviderChain, type AiProvider } from './provider.js';
+import { createCompatAiProvider } from './providers/compat.js';
+import { createOpenAiProvider } from './providers/openai.js';
 import {
   aiNormalizedDraftSchema,
   aiRawGeneratedEndpointSchema,
@@ -67,20 +69,12 @@ function createAiUnavailableError(): AppError {
   });
 }
 
-function createAiMissingConfigError(): AppError {
+function createAiMissingConfigError(details: string): AppError {
   return new AppError(503, 'AI is unavailable right now', {
     code: AI_MISSING_CONFIG_CODE,
     retryable: false,
-    details: 'OPENAI_API_KEY is not configured',
+    details,
   });
-}
-
-function getOpenAiClient(): OpenAI {
-  if (!env.OPENAI_API_KEY) {
-    throw createAiMissingConfigError();
-  }
-
-  return new OpenAI({ apiKey: env.OPENAI_API_KEY });
 }
 
 function createAiInvalidOutputError(): AppError {
@@ -99,47 +93,8 @@ function extractJson(text: string): string {
   return text.trim();
 }
 
-async function createAiCompletion(prompt: string): Promise<AiRawGeneratedEndpointInput> {
-  const completionPromise = getOpenAiClient().chat.completions.create({
-    model: env.OPENAI_MODEL,
-    temperature: 0.2,
-    response_format: { type: 'json_object' },
-    messages: [
-      { role: 'system', content: SYSTEM_PROMPT },
-      { role: 'user', content: prompt },
-    ],
-  });
-
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => {
-      reject(createAiTimeoutError());
-    }, 30_000);
-  });
-
-  let completion;
-
-  try {
-    completion = await Promise.race([completionPromise, timeoutPromise]);
-  } catch (error) {
-    const errorCode =
-      typeof error === 'object' && error !== null && 'code' in error
-        ? (error as { code?: unknown }).code
-        : undefined;
-
-    if (error instanceof AppError) {
-      throw error;
-    }
-
-    if (errorCode === 'ETIMEDOUT') {
-      throw createAiTimeoutError();
-    }
-
-    throw createAiUnavailableError();
-  }
-
-  const rawContent = completion.choices[0]?.message?.content;
-
-  if (!rawContent) {
+function parseAiCompletion(rawContent: string): AiRawGeneratedEndpointInput {
+  if (!rawContent.trim()) {
     throw new AiShapeValidationError('AI returned empty content');
   }
 
@@ -158,6 +113,69 @@ async function createAiCompletion(prompt: string): Promise<AiRawGeneratedEndpoin
   }
 
   return parsed.data;
+}
+
+function buildAiProviders(): AiProvider[] {
+  return resolveAiProviderChain(env).map((providerName) => {
+    if (providerName === 'compat') {
+      return createCompatAiProvider(env, { systemPrompt: SYSTEM_PROMPT });
+    }
+
+    return createOpenAiProvider(env, { systemPrompt: SYSTEM_PROMPT });
+  });
+}
+
+function mapProviderExecutionError(error: AiProviderExecutionError): AppError {
+  if (error.kind === 'timeout') {
+    return createAiTimeoutError();
+  }
+
+  if (error.kind === 'missing-config') {
+    return createAiMissingConfigError(error.details ?? `${error.provider} is not configured`);
+  }
+
+  return createAiUnavailableError();
+}
+
+export async function createNormalizedDraftWithFallback(
+  prompt: string,
+  providers: AiProvider[] = buildAiProviders()
+): Promise<AiPreviewResponseInput> {
+  if (providers.length === 0) {
+    throw createAiMissingConfigError('No AI providers are configured');
+  }
+
+  let lastExecutionError: AiProviderExecutionError | null = null;
+
+  for (const provider of providers) {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const generated = parseAiCompletion(await provider.generateJson(prompt));
+        return normalizeAiDraft(generated);
+      } catch (error) {
+        if (error instanceof AiProviderExecutionError) {
+          lastExecutionError = error;
+          break;
+        }
+
+        if (error instanceof AiShapeValidationError) {
+          if (attempt === 1) {
+            throw createAiInvalidOutputError();
+          }
+
+          continue;
+        }
+
+        throw createAiUnavailableError();
+      }
+    }
+  }
+
+  if (lastExecutionError) {
+    throw mapProviderExecutionError(lastExecutionError);
+  }
+
+  throw createAiUnavailableError();
 }
 
 function toPersistedDraft(previewDraft: AiPreviewResponseInput): AiNormalizedDraftInput {
@@ -226,33 +244,7 @@ async function persistGeneratedEndpoint(projectId: string, generated: AiNormaliz
 }
 
 async function generateNormalizedDraft(prompt: string): Promise<AiPreviewResponseInput> {
-  let lastValidationError: string | null = null;
-
-  for (let attempt = 0; attempt < 2; attempt += 1) {
-    try {
-      const generated = await createAiCompletion(prompt);
-      return normalizeAiDraft(generated);
-    } catch (error) {
-      if (error instanceof AppError) {
-        throw error;
-      }
-
-      if (error instanceof AiShapeValidationError) {
-        lastValidationError = error.message;
-
-        if (attempt === 1) {
-          break;
-        }
-
-        continue;
-      }
-
-      throw createAiUnavailableError();
-    }
-  }
-
-  void lastValidationError;
-  throw createAiInvalidOutputError();
+  return createNormalizedDraftWithFallback(prompt);
 }
 
 export async function generateEndpointPreview(
@@ -275,3 +267,5 @@ export async function generateEndpointWithAi(
   const previewDraft = await generateNormalizedDraft(prompt);
   return persistGeneratedEndpoint(projectId, toPersistedDraft(previewDraft));
 }
+
+export { AiProviderExecutionError, type AiProvider };


### PR DESCRIPTION
Closes #59

## Summary
- add a backend AI provider abstraction with OpenAI primary support and OpenAI-compatible fallback support
- preserve the existing AI HTTP contracts while routing preview and generate flows through primary-first failover
- cover provider selection, malformed-output behavior, and persisted fallback execution with focused backend tests

## Changes
| File | Change |
|------|--------|
| pps/backend/src/management/ai/provider.ts | Added provider contract, provider-chain resolution, and execution error typing |
| pps/backend/src/management/ai/providers/openai.ts | Extracted the OpenAI adapter behind the shared provider interface |
| pps/backend/src/management/ai/providers/compat.ts | Added OpenAI-compatible fallback adapter support |
| pps/backend/src/management/ai/service.ts | Switched AI preview/generate orchestration to primary-first fallback without changing API contracts |
| pps/backend/src/config/env.ts | Added env parsing for primary/fallback provider configuration with OpenAI-compatible settings |
| pps/backend/src/config/env.test.ts | Added provider-chain env parsing coverage |
| pps/backend/src/management/ai/provider.test.ts | Added focused provider-chain and fallback unit coverage |
| pps/backend/src/management/ai/service.test.ts | Added focused service tests for fallback-only-on-execution-failure behavior |
| pps/backend/src/__tests__/app.integration.test.ts | Added end-to-end AI preview/generate fallback assertions |

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan
- [x] pnpm vitest run src/config/env.test.ts src/management/ai/provider.test.ts src/management/ai/service.test.ts src/__tests__/app.integration.test.ts --coverage (from pps/backend)
- [x] pnpm exec tsc --noEmit --pretty false (from pps/backend)
- [x] pnpm exec eslint src/config/env.ts src/config/env.test.ts src/management/ai/provider.ts src/management/ai/provider.test.ts src/management/ai/providers/openai.ts src/management/ai/providers/compat.ts src/management/ai/service.ts src/management/ai/service.test.ts src/__tests__/app.integration.test.ts (from pps/backend)
- [ ] Manual exploratory testing

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one 	ype:* label
- [x] No shell scripts were modified, so shellcheck was not needed
- [x] Conventional commit format used
- [x] No Co-Authored-By trailers
- [ ] Docs updated if behavior changed