### PR TITLE
feat(ai): add preview cache foundation

### DIFF
--- a/apps/backend/src/__tests__/app.integration.test.ts
+++ b/apps/backend/src/__tests__/app.integration.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Express } from 'express';
 import { resetRateLimitStoreForTests } from '../mock-server/rate-limit.js';
+import { resetAiPreviewCacheForTests } from '../management/ai/service.js';
 
 const openaiCreateMock = vi.fn();
 const openAiClientConfigs: Array<Record<string, unknown> | undefined> = [];
@@ -217,6 +218,7 @@ describe('app integration', () => {
     prismaMock.$transaction.mockReset();
     openaiCreateMock.mockReset();
     openAiClientConfigs.length = 0;
+    resetAiPreviewCacheForTests();
     resetRateLimitStoreForTests();
     runtimeRateLimitBuckets.clear();
     prismaMock.runtimeRateLimitBucket.upsert.mockImplementation(
@@ -1641,6 +1643,50 @@ describe('app integration', () => {
     expect(prismaMock.$transaction).not.toHaveBeenCalled();
   });
 
+  it('POST /api/v1/projects/:projectId/endpoints/ai-preview reutiliza un hit en memoria para requests idénticos', async () => {
+    prismaMock.project.findUnique.mockResolvedValue({ id: 'p1', workspaceId: 'workspace-1' });
+    openaiCreateMock.mockResolvedValueOnce({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              method: 'GET',
+              path: '/users',
+              description: 'List users',
+              statusCode: 200,
+              responseBody: [{ id: 'u1' }],
+              scenarios: [
+                {
+                  name: 'success',
+                  type: 'success',
+                  statusCode: 200,
+                  body: [{ id: 'u1' }],
+                  delayMs: 0,
+                  weight: 1,
+                },
+              ],
+            }),
+          },
+        },
+      ],
+    });
+
+    const firstResponse = await request(app)
+      .post('/api/v1/projects/p1/endpoints/ai-preview')
+      .set(authHeaders())
+      .send({ prompt: 'Generate a users endpoint preview with cached success response' });
+
+    const secondResponse = await request(app)
+      .post('/api/v1/projects/p1/endpoints/ai-preview')
+      .set(authHeaders())
+      .send({ prompt: 'Generate a users endpoint preview with cached success response' });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.body).toEqual(firstResponse.body);
+    expect(openaiCreateMock).toHaveBeenCalledTimes(1);
+  });
+
   it('POST /api/v1/projects/:projectId/endpoints/ai-preview responde AI_UNAVAILABLE cuando OpenAI falla', async () => {
     prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
     openaiCreateMock.mockRejectedValueOnce(new Error('upstream unavailable'));
@@ -1890,5 +1936,99 @@ describe('app integration', () => {
       env.AI_COMPAT_MODEL = originalCompatModel;
       env.AI_COMPAT_BASE_URL = originalCompatBaseUrl;
     }
+  });
+
+  it('POST /api/v1/projects/:projectId/endpoints/ai-generate ignora previews cacheados y persiste por su flujo normal', async () => {
+    prismaMock.project.findUnique.mockResolvedValue({ id: 'p1', workspaceId: 'workspace-1' });
+    prismaMock.endpoint.findFirst.mockResolvedValueOnce(null);
+
+    openaiCreateMock
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                method: 'GET',
+                path: '/users',
+                description: 'List users',
+                statusCode: 200,
+                responseBody: [{ id: 'u1' }],
+                scenarios: [
+                  {
+                    name: 'success',
+                    type: 'success',
+                    statusCode: 200,
+                    body: [{ id: 'u1' }],
+                    delayMs: 0,
+                    weight: 1,
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                method: 'GET',
+                path: '/users',
+                description: 'List users',
+                statusCode: 200,
+                responseBody: [{ id: 'u1' }],
+                scenarios: [
+                  {
+                    name: 'success',
+                    type: 'success',
+                    statusCode: 200,
+                    body: [{ id: 'u1' }],
+                    delayMs: 0,
+                    weight: 1,
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      });
+
+    const tx = {
+      endpoint: {
+        create: vi.fn().mockResolvedValue({ id: 'e-ai-cache-bypass-1' }),
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: 'e-ai-cache-bypass-1',
+          method: 'GET',
+          path: '/users',
+          endpointConfig: { endpointId: 'e-ai-cache-bypass-1' },
+          scenarios: [{ id: 's-ai-cache-bypass-1', type: 'success' }],
+        }),
+      },
+      endpointConfig: {
+        create: vi.fn().mockResolvedValue({ id: 'cfg-ai-cache-bypass-1' }),
+      },
+      scenario: {
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementationOnce(async (callback) => callback(tx));
+
+    const previewResponse = await request(app)
+      .post('/api/v1/projects/p1/endpoints/ai-preview')
+      .set(authHeaders())
+      .send({ prompt: 'Generate a users endpoint preview before persisted generation' });
+
+    const generateResponse = await request(app)
+      .post('/api/v1/projects/p1/endpoints/ai-generate')
+      .set(authHeaders())
+      .send({ prompt: 'Generate a users endpoint preview before persisted generation' });
+
+    expect(previewResponse.status).toBe(200);
+    expect(generateResponse.status).toBe(201);
+    expect(tx.endpoint.create).toHaveBeenCalledTimes(1);
+    expect(tx.scenario.createMany).toHaveBeenCalledTimes(1);
+    expect(openaiCreateMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/backend/src/management/ai/service.test.ts
+++ b/apps/backend/src/management/ai/service.test.ts
@@ -1,10 +1,36 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { normalizeAiDraft } from './normalize-draft.js';
+import type { AuthenticatedActor } from '../../auth/types.js';
+
+const authorizeProjectAccessMock = vi.fn();
+
+vi.mock('../../auth/authorization.js', () => ({
+  authorizeProjectAccess: authorizeProjectAccessMock,
+}));
+
 import {
   AiProviderExecutionError,
   createNormalizedDraftWithFallback,
+  generateEndpointPreview,
+  resetAiPreviewCacheForTests,
   type AiProvider,
 } from './service.js';
+
+const actor: AuthenticatedActor = {
+  userId: 'user-1',
+  personalWorkspaceId: 'workspace-1',
+  identity: {
+    provider: 'clerk',
+    subject: 'user_clerk_123',
+  },
+  workspaceMemberships: [{ workspaceId: 'workspace-1', role: 'owner' }],
+};
+
+beforeEach(() => {
+  authorizeProjectAccessMock.mockReset();
+  authorizeProjectAccessMock.mockResolvedValue({ id: 'p1', workspaceId: 'workspace-1' });
+  resetAiPreviewCacheForTests();
+});
 
 describe('normalizeAiDraft', () => {
   it('normaliza method/path y expone locks para preview/persist', () => {
@@ -203,6 +229,259 @@ describe('createNormalizedDraftWithFallback', () => {
         code: 'AI_UNAVAILABLE',
         retryable: false,
       },
+    });
+  });
+});
+
+describe('generateEndpointPreview cache', () => {
+  it('reutiliza previews cacheados por projectId y prompt normalizado sin filtrar mutaciones previas', async () => {
+    const provider = {
+      name: 'openai',
+      generateJson: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          method: 'POST',
+          path: '/users',
+          description: 'Create user',
+          statusCode: 201,
+          responseBody: { id: 'u1' },
+          scenarios: [
+            {
+              name: 'success',
+              type: 'success',
+              statusCode: 201,
+              body: { id: 'u1' },
+              delayMs: 0,
+              weight: 1,
+            },
+          ],
+        })
+      ),
+    } satisfies AiProvider;
+
+    const firstPreview = await generateEndpointPreview(actor, 'p1', '  Generate users  ', {
+      providers: [provider],
+      nowMs: 1_000,
+    });
+
+    firstPreview.scenarios[0]!.name = 'mutated in test';
+    firstPreview.responseBody = { id: 'mutated' };
+
+    const cachedPreview = await generateEndpointPreview(actor, 'p1', 'Generate users', {
+      providers: [provider],
+      nowMs: 1_001,
+    });
+
+    expect(provider.generateJson).toHaveBeenCalledTimes(1);
+    expect(cachedPreview).toMatchObject({
+      method: 'POST',
+      path: '/users',
+      responseBody: { id: 'u1' },
+      scenarios: [{ name: 'success', type: 'success' }],
+    });
+  });
+
+  it('aísla cache por projectId aun con el mismo prompt normalizado', async () => {
+    const provider = {
+      name: 'openai',
+      generateJson: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          method: 'GET',
+          path: '/users',
+          description: 'List users',
+          statusCode: 200,
+          responseBody: [{ id: 'u1' }],
+          scenarios: [
+            {
+              name: 'success',
+              type: 'success',
+              statusCode: 200,
+              body: [{ id: 'u1' }],
+              delayMs: 0,
+              weight: 1,
+            },
+          ],
+        })
+      ),
+    } satisfies AiProvider;
+
+    await generateEndpointPreview(actor, 'p1', 'Generate users', {
+      providers: [provider],
+      nowMs: 2_000,
+    });
+    await generateEndpointPreview(actor, 'p2', 'Generate users', {
+      providers: [provider],
+      nowMs: 2_001,
+    });
+
+    expect(provider.generateJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('expira entradas y permite reset explícito para pruebas determinísticas', async () => {
+    const provider = {
+      name: 'openai',
+      generateJson: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          method: 'GET',
+          path: '/reports',
+          description: 'List reports',
+          statusCode: 200,
+          responseBody: [],
+          scenarios: [
+            {
+              name: 'success',
+              type: 'success',
+              statusCode: 200,
+              body: [],
+              delayMs: 0,
+              weight: 1,
+            },
+          ],
+        })
+      ),
+    } satisfies AiProvider;
+
+    await generateEndpointPreview(actor, 'p1', 'Generate reports', {
+      providers: [provider],
+      nowMs: 3_000,
+    });
+    await generateEndpointPreview(actor, 'p1', 'Generate reports', {
+      providers: [provider],
+      nowMs: 303_000,
+    });
+
+    resetAiPreviewCacheForTests();
+
+    await generateEndpointPreview(actor, 'p1', 'Generate reports', {
+      providers: [provider],
+      nowMs: 303_001,
+    });
+
+    expect(provider.generateJson).toHaveBeenCalledTimes(3);
+  });
+
+  it('no cachea errores AI_UNAVAILABLE y reintenta en cada request', async () => {
+    const provider = {
+      name: 'openai',
+      generateJson: vi
+        .fn()
+        .mockRejectedValue(new AiProviderExecutionError('openai', 'unavailable')),
+    } satisfies AiProvider;
+
+    await expect(
+      generateEndpointPreview(actor, 'p1', 'Generate users with outage', {
+        providers: [provider],
+        nowMs: 4_000,
+      })
+    ).rejects.toMatchObject({
+      options: { code: 'AI_UNAVAILABLE', retryable: true },
+    });
+
+    await expect(
+      generateEndpointPreview(actor, 'p1', 'Generate users with outage', {
+        providers: [provider],
+        nowMs: 4_001,
+      })
+    ).rejects.toMatchObject({
+      options: { code: 'AI_UNAVAILABLE', retryable: true },
+    });
+
+    expect(provider.generateJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('no cachea errores AI_TIMEOUT y permite regenerar en el siguiente request', async () => {
+    const provider = {
+      name: 'openai',
+      generateJson: vi
+        .fn()
+        .mockRejectedValueOnce(new AiProviderExecutionError('openai', 'timeout'))
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            method: 'GET',
+            path: '/users',
+            description: 'List users after retry',
+            statusCode: 200,
+            responseBody: [{ id: 'u1' }],
+            scenarios: [
+              {
+                name: 'success',
+                type: 'success',
+                statusCode: 200,
+                body: [{ id: 'u1' }],
+                delayMs: 0,
+                weight: 1,
+              },
+            ],
+          })
+        ),
+    } satisfies AiProvider;
+
+    await expect(
+      generateEndpointPreview(actor, 'p1', 'Generate users after timeout', {
+        providers: [provider],
+        nowMs: 5_000,
+      })
+    ).rejects.toMatchObject({
+      options: { code: 'AI_TIMEOUT', retryable: true },
+    });
+
+    await expect(
+      generateEndpointPreview(actor, 'p1', 'Generate users after timeout', {
+        providers: [provider],
+        nowMs: 5_001,
+      })
+    ).resolves.toMatchObject({
+      method: 'GET',
+      path: '/users',
+      responseBody: [{ id: 'u1' }],
+    });
+  });
+
+  it('no cachea errores AI_INVALID_OUTPUT y vuelve a generar en el siguiente request', async () => {
+    const provider = {
+      name: 'openai',
+      generateJson: vi
+        .fn()
+        .mockResolvedValueOnce(JSON.stringify({ method: 'GET', scenarios: [] }))
+        .mockResolvedValueOnce(JSON.stringify({ method: 'GET', scenarios: [] }))
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            method: 'POST',
+            path: '/users',
+            description: 'Create user after invalid output',
+            statusCode: 201,
+            responseBody: { id: 'u1' },
+            scenarios: [
+              {
+                name: 'success',
+                type: 'success',
+                statusCode: 201,
+                body: { id: 'u1' },
+                delayMs: 0,
+                weight: 1,
+              },
+            ],
+          })
+        ),
+    } satisfies AiProvider;
+
+    await expect(
+      generateEndpointPreview(actor, 'p1', 'Generate users after invalid output', {
+        providers: [provider],
+        nowMs: 6_000,
+      })
+    ).rejects.toMatchObject({
+      options: { code: 'AI_INVALID_OUTPUT', retryable: true },
+    });
+
+    await expect(
+      generateEndpointPreview(actor, 'p1', 'Generate users after invalid output', {
+        providers: [provider],
+        nowMs: 6_001,
+      })
+    ).resolves.toMatchObject({
+      method: 'POST',
+      path: '/users',
+      responseBody: { id: 'u1' },
     });
   });
 });

--- a/apps/backend/src/management/ai/service.ts
+++ b/apps/backend/src/management/ai/service.ts
@@ -8,6 +8,7 @@ import { createCompatAiProvider } from './providers/compat.js';
 import { createOpenAiProvider } from './providers/openai.js';
 import {
   aiNormalizedDraftSchema,
+  aiPreviewResponseSchema,
   aiRawGeneratedEndpointSchema,
   type AiNormalizedDraftInput,
   type AiPreviewResponseInput,
@@ -52,6 +53,91 @@ const AI_TIMEOUT_CODE = 'AI_TIMEOUT';
 const AI_UNAVAILABLE_CODE = 'AI_UNAVAILABLE';
 const AI_INVALID_OUTPUT_CODE = 'AI_INVALID_OUTPUT';
 const AI_MISSING_CONFIG_CODE = 'AI_UNAVAILABLE';
+const AI_PREVIEW_CACHE_TTL_MS = 5 * 60_000;
+const AI_PREVIEW_CACHE_MAX_ENTRIES = 100;
+
+interface PreviewCacheEntry {
+  value: AiPreviewResponseInput;
+  expiresAtMs: number;
+}
+
+interface AiPreviewRuntimeOptions {
+  providers?: AiProvider[];
+  nowMs?: number;
+}
+
+const previewCache = new Map<string, PreviewCacheEntry>();
+
+function clonePreviewValue(value: AiPreviewResponseInput): AiPreviewResponseInput {
+  return aiPreviewResponseSchema.parse(structuredClone(value));
+}
+
+function normalizePreviewCachePrompt(prompt: string): string {
+  return prompt.trim();
+}
+
+function buildPreviewCacheKey(projectId: string, prompt: string): string {
+  return `${projectId}:${normalizePreviewCachePrompt(prompt)}`;
+}
+
+function pruneExpiredPreviewCacheEntries(nowMs: number): void {
+  for (const [key, entry] of previewCache.entries()) {
+    if (entry.expiresAtMs <= nowMs) {
+      previewCache.delete(key);
+    }
+  }
+}
+
+function evictPreviewCacheEntriesIfNeeded(): void {
+  while (previewCache.size >= AI_PREVIEW_CACHE_MAX_ENTRIES) {
+    const oldestKey = previewCache.keys().next().value;
+
+    if (!oldestKey) {
+      return;
+    }
+
+    previewCache.delete(oldestKey);
+  }
+}
+
+function readPreviewCache(
+  projectId: string,
+  prompt: string,
+  nowMs: number
+): AiPreviewResponseInput | null {
+  pruneExpiredPreviewCacheEntries(nowMs);
+
+  const entry = previewCache.get(buildPreviewCacheKey(projectId, prompt));
+
+  if (!entry) {
+    return null;
+  }
+
+  return clonePreviewValue(entry.value);
+}
+
+function writePreviewCache(
+  projectId: string,
+  prompt: string,
+  value: AiPreviewResponseInput,
+  nowMs: number
+): AiPreviewResponseInput {
+  pruneExpiredPreviewCacheEntries(nowMs);
+  evictPreviewCacheEntriesIfNeeded();
+
+  const clonedValue = clonePreviewValue(value);
+
+  previewCache.set(buildPreviewCacheKey(projectId, prompt), {
+    value: clonedValue,
+    expiresAtMs: nowMs + AI_PREVIEW_CACHE_TTL_MS,
+  });
+
+  return clonePreviewValue(clonedValue);
+}
+
+export function resetAiPreviewCacheForTests(): void {
+  previewCache.clear();
+}
 
 function createAiTimeoutError(): AppError {
   return new AppError(504, 'AI request timed out', {
@@ -257,18 +343,30 @@ async function persistGeneratedEndpoint(projectId: string, generated: AiNormaliz
   });
 }
 
-async function generateNormalizedDraft(prompt: string): Promise<AiPreviewResponseInput> {
-  return createNormalizedDraftWithFallback(prompt);
+async function generateNormalizedDraft(
+  prompt: string,
+  providers?: AiProvider[]
+): Promise<AiPreviewResponseInput> {
+  return createNormalizedDraftWithFallback(prompt, providers);
 }
 
 export async function generateEndpointPreview(
   actor: AuthenticatedActor,
   projectId: string,
-  prompt: string
+  prompt: string,
+  runtimeOptions: AiPreviewRuntimeOptions = {}
 ) {
   await authorizeAiProjectMutation(actor, projectId);
 
-  return generateNormalizedDraft(prompt);
+  const nowMs = runtimeOptions.nowMs ?? Date.now();
+  const cachedPreview = readPreviewCache(projectId, prompt, nowMs);
+
+  if (cachedPreview) {
+    return cachedPreview;
+  }
+
+  const preview = await generateNormalizedDraft(prompt, runtimeOptions.providers);
+  return writePreviewCache(projectId, prompt, preview, nowMs);
 }
 
 export async function generateEndpointWithAi(


### PR DESCRIPTION
Closes #61

## Summary
- add a backend-only in-memory cache for successful i-preview responses
- keep the cache strictly preview-only so i-generate stays on its existing uncached persistence flow
- cover cache hits, miss behavior, expiry/reset, and non-cached error paths with focused backend tests

## Changes
| File | Change |
|------|--------|
| pps/backend/src/management/ai/service.ts | Added preview-only in-memory cache helpers, bounded TTL-based storage, and preview entrypoint wiring |
| pps/backend/src/management/ai/service.test.ts | Added focused unit coverage for cache hits, expiry, reset, and non-cached error scenarios |
| pps/backend/src/__tests__/app.integration.test.ts | Added integration assertions for preview cache reuse and i-generate bypassing cached previews |

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan
- [x] pnpm --dir apps/backend test -- src/management/ai/service.test.ts
- [x] pnpm --dir apps/backend exec tsc --noEmit --pretty false
- [x] Focused strict-TDD verify rerun passed for issue-61-ai-preview-caching (62/62 tests, eslint clean)
- [ ] Manual exploratory testing

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one 	ype:* label
- [x] No shell scripts were modified, so shellcheck was not needed
- [x] Conventional commit format used
- [x] No Co-Authored-By trailers
- [ ] Docs updated if behavior changed