### PR TITLE
feat(ai): add prompt versioning foundation

### DIFF
--- a/apps/backend/src/__tests__/app.integration.test.ts
+++ b/apps/backend/src/__tests__/app.integration.test.ts
@@ -2,6 +2,7 @@ import request from 'supertest';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Express } from 'express';
 import { resetRateLimitStoreForTests } from '../mock-server/rate-limit.js';
+import { activeAiPromptDescriptor } from '../management/ai/prompt-descriptor.js';
 import { resetAiPreviewCacheForTests } from '../management/ai/service.js';
 
 const openaiCreateMock = vi.fn();
@@ -1687,6 +1688,88 @@ describe('app integration', () => {
     expect(openaiCreateMock).toHaveBeenCalledTimes(1);
   });
 
+  it('POST /api/v1/projects/:projectId/endpoints/ai-preview invalida el cache cuando cambia el modelo backend sin cambiar el payload HTTP', async () => {
+    prismaMock.project.findUnique.mockResolvedValue({ id: 'p1', workspaceId: 'workspace-1' });
+    const { env } = await import('../config/env.js');
+    const originalModel = env.OPENAI_MODEL;
+
+    openaiCreateMock
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                method: 'GET',
+                path: '/users',
+                description: 'List users v1',
+                statusCode: 200,
+                responseBody: [{ id: 'u1' }],
+                scenarios: [
+                  {
+                    name: 'success',
+                    type: 'success',
+                    statusCode: 200,
+                    body: [{ id: 'u1' }],
+                    delayMs: 0,
+                    weight: 1,
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                method: 'GET',
+                path: '/users',
+                description: 'List users v2',
+                statusCode: 200,
+                responseBody: [{ id: 'u2' }],
+                scenarios: [
+                  {
+                    name: 'success',
+                    type: 'success',
+                    statusCode: 200,
+                    body: [{ id: 'u2' }],
+                    delayMs: 0,
+                    weight: 1,
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      });
+
+    try {
+      env.OPENAI_MODEL = 'gpt-4.1-mini';
+
+      const firstResponse = await request(app)
+        .post('/api/v1/projects/p1/endpoints/ai-preview')
+        .set(authHeaders())
+        .send({ prompt: 'Generate a users endpoint preview with cached success response' });
+
+      env.OPENAI_MODEL = 'gpt-4.1-nano';
+
+      const secondResponse = await request(app)
+        .post('/api/v1/projects/p1/endpoints/ai-preview')
+        .set(authHeaders())
+        .send({ prompt: 'Generate a users endpoint preview with cached success response' });
+
+      expect(firstResponse.status).toBe(200);
+      expect(secondResponse.status).toBe(200);
+      expect(firstResponse.body).toMatchObject({ description: 'List users v1' });
+      expect(secondResponse.body).toMatchObject({ description: 'List users v2' });
+      expect(openaiCreateMock).toHaveBeenCalledTimes(2);
+    } finally {
+      env.OPENAI_MODEL = originalModel;
+    }
+  });
+
   it('POST /api/v1/projects/:projectId/endpoints/ai-preview responde AI_UNAVAILABLE cuando OpenAI falla', async () => {
     prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
     openaiCreateMock.mockRejectedValueOnce(new Error('upstream unavailable'));
@@ -2030,5 +2113,107 @@ describe('app integration', () => {
     expect(tx.endpoint.create).toHaveBeenCalledTimes(1);
     expect(tx.scenario.createMany).toHaveBeenCalledTimes(1);
     expect(openaiCreateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('POST preview y generate reutilizan el mismo prompt descriptor y el prompt trimmeado con payload HTTP mínimo', async () => {
+    const prompt = '  Generate a users endpoint preview before persisted generation  ';
+    prismaMock.project.findUnique.mockResolvedValue({ id: 'p1', workspaceId: 'workspace-1' });
+    prismaMock.endpoint.findFirst.mockResolvedValueOnce(null);
+
+    openaiCreateMock
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                method: 'GET',
+                path: '/users',
+                description: 'List users',
+                statusCode: 200,
+                responseBody: [{ id: 'u1' }],
+                scenarios: [
+                  {
+                    name: 'success',
+                    type: 'success',
+                    statusCode: 200,
+                    body: [{ id: 'u1' }],
+                    delayMs: 0,
+                    weight: 1,
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                method: 'GET',
+                path: '/users',
+                description: 'List users',
+                statusCode: 200,
+                responseBody: [{ id: 'u1' }],
+                scenarios: [
+                  {
+                    name: 'success',
+                    type: 'success',
+                    statusCode: 200,
+                    body: [{ id: 'u1' }],
+                    delayMs: 0,
+                    weight: 1,
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      });
+
+    const tx = {
+      endpoint: {
+        create: vi.fn().mockResolvedValue({ id: 'e-ai-identity-1' }),
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: 'e-ai-identity-1',
+          method: 'GET',
+          path: '/users',
+          endpointConfig: { endpointId: 'e-ai-identity-1' },
+          scenarios: [{ id: 's-ai-identity-1', type: 'success' }],
+        }),
+      },
+      endpointConfig: {
+        create: vi.fn().mockResolvedValue({ id: 'cfg-ai-identity-1' }),
+      },
+      scenario: {
+        createMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementationOnce(async (callback) => callback(tx));
+
+    const previewResponse = await request(app)
+      .post('/api/v1/projects/p1/endpoints/ai-preview')
+      .set(authHeaders())
+      .send({ prompt });
+
+    const generateResponse = await request(app)
+      .post('/api/v1/projects/p1/endpoints/ai-generate')
+      .set(authHeaders())
+      .send({ prompt });
+
+    expect(previewResponse.status).toBe(200);
+    expect(generateResponse.status).toBe(201);
+    expect(openaiCreateMock).toHaveBeenCalledTimes(2);
+
+    const previewMessages = openaiCreateMock.mock.calls[0]?.[0]?.messages;
+    const generateMessages = openaiCreateMock.mock.calls[1]?.[0]?.messages;
+
+    expect(previewMessages).toEqual([
+      { role: 'system', content: activeAiPromptDescriptor.systemPrompt },
+      { role: 'user', content: prompt.trim() },
+    ]);
+    expect(generateMessages).toEqual(previewMessages);
   });
 });

--- a/apps/backend/src/management/ai/execution-identity.test.ts
+++ b/apps/backend/src/management/ai/execution-identity.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import type { Env } from '../../config/env.js';
+import {
+  buildAiExecutionIdentity,
+  buildAiPreviewCacheKey,
+  buildProviderFingerprint,
+} from './execution-identity.js';
+import { activeAiPromptDescriptor } from './prompt-descriptor.js';
+
+function buildEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    NODE_ENV: 'test',
+    PORT: 3000,
+    DATABASE_URL: 'postgresql://user:password@localhost:5432/simulador_api_ia_test',
+    AI_PRIMARY_PROVIDER: 'openai',
+    AI_FALLBACK_PROVIDER: undefined,
+    AI_COMPAT_API_KEY: undefined,
+    AI_COMPAT_MODEL: undefined,
+    AI_COMPAT_BASE_URL: undefined,
+    OPENAI_API_KEY: 'openai-key',
+    OPENAI_MODEL: 'gpt-4.1-mini',
+    MOCK_BASE_URL: 'http://localhost:3000/mock',
+    CORS_ALLOWED_ORIGINS: undefined,
+    ...overrides,
+  };
+}
+
+describe('buildAiExecutionIdentity', () => {
+  it('resuelve el descriptor activo con id, version y fingerprint determinístico', () => {
+    const identity = buildAiExecutionIdentity(
+      buildEnv({
+        AI_PRIMARY_PROVIDER: 'compat',
+        AI_FALLBACK_PROVIDER: 'openai',
+        AI_COMPAT_API_KEY: 'compat-key',
+        AI_COMPAT_MODEL: 'compat-model',
+        AI_COMPAT_BASE_URL: 'https://compat.example.com/v1',
+        OPENAI_MODEL: 'gpt-4.1-mini',
+      }),
+      'p1',
+      '  Generate users  ',
+      activeAiPromptDescriptor
+    );
+
+    expect(identity).toEqual({
+      projectId: 'p1',
+      normalizedPrompt: 'Generate users',
+      prompt: {
+        id: activeAiPromptDescriptor.id,
+        version: activeAiPromptDescriptor.version,
+      },
+      providerFingerprint: [
+        'compat:compat-model:https://compat.example.com/v1',
+        'openai:gpt-4.1-mini',
+      ],
+    });
+  });
+
+  it('normaliza el prompt sólo con trim y conserva cambios internos', () => {
+    const trimmedIdentity = buildAiExecutionIdentity(
+      buildEnv(),
+      'p1',
+      '  Generate users  ',
+      activeAiPromptDescriptor
+    );
+
+    const internalWhitespaceIdentity = buildAiExecutionIdentity(
+      buildEnv(),
+      'p1',
+      'Generate   users',
+      activeAiPromptDescriptor
+    );
+
+    expect(trimmedIdentity.normalizedPrompt).toBe('Generate users');
+    expect(buildAiPreviewCacheKey(trimmedIdentity)).toBe(
+      buildAiPreviewCacheKey(
+        buildAiExecutionIdentity(buildEnv(), 'p1', 'Generate users', activeAiPromptDescriptor)
+      )
+    );
+    expect(internalWhitespaceIdentity.normalizedPrompt).toBe('Generate   users');
+    expect(buildAiPreviewCacheKey(internalWhitespaceIdentity)).not.toBe(
+      buildAiPreviewCacheKey(trimmedIdentity)
+    );
+  });
+});
+
+describe('buildProviderFingerprint', () => {
+  it('incluye provider/model/baseURL con orden estable para la cadena resuelta', () => {
+    expect(
+      buildProviderFingerprint(
+        buildEnv({
+          AI_PRIMARY_PROVIDER: 'compat',
+          AI_FALLBACK_PROVIDER: 'openai',
+          AI_COMPAT_API_KEY: 'compat-key',
+          AI_COMPAT_MODEL: 'compat-model',
+          AI_COMPAT_BASE_URL: 'https://compat.example.com/v1',
+          OPENAI_MODEL: 'gpt-4.1-mini',
+        })
+      )
+    ).toEqual(['compat:compat-model:https://compat.example.com/v1', 'openai:gpt-4.1-mini']);
+  });
+
+  it('deduplica la cadena de providers sin perder el fingerprint del modelo activo', () => {
+    expect(
+      buildProviderFingerprint(
+        buildEnv({
+          AI_PRIMARY_PROVIDER: 'openai',
+          AI_FALLBACK_PROVIDER: 'openai',
+          OPENAI_MODEL: 'gpt-4.1-nano',
+        })
+      )
+    ).toEqual(['openai:gpt-4.1-nano']);
+  });
+});

--- a/apps/backend/src/management/ai/execution-identity.ts
+++ b/apps/backend/src/management/ai/execution-identity.ts
@@ -1,0 +1,51 @@
+import type { Env } from '../../config/env.js';
+import { resolveAiProviderChain } from './provider.js';
+import type { AiPromptDescriptor } from './prompt-descriptor.js';
+
+export interface AiExecutionIdentity {
+  projectId: string;
+  normalizedPrompt: string;
+  prompt: Pick<AiPromptDescriptor, 'id' | 'version'>;
+  providerFingerprint: string[];
+}
+
+export function normalizeAiPromptInput(prompt: string): string {
+  return prompt.trim();
+}
+
+export function buildProviderFingerprint(env: Env): string[] {
+  return resolveAiProviderChain(env).map((provider) => {
+    if (provider === 'compat') {
+      return `compat:${env.AI_COMPAT_MODEL ?? 'missing-model'}:${env.AI_COMPAT_BASE_URL ?? 'missing-base-url'}`;
+    }
+
+    return `openai:${env.OPENAI_MODEL}`;
+  });
+}
+
+export function buildAiExecutionIdentity(
+  env: Env,
+  projectId: string,
+  prompt: string,
+  descriptor: AiPromptDescriptor
+): AiExecutionIdentity {
+  return {
+    projectId,
+    normalizedPrompt: normalizeAiPromptInput(prompt),
+    prompt: {
+      id: descriptor.id,
+      version: descriptor.version,
+    },
+    providerFingerprint: buildProviderFingerprint(env),
+  };
+}
+
+export function buildAiPreviewCacheKey(identity: AiExecutionIdentity): string {
+  return JSON.stringify([
+    identity.projectId,
+    identity.normalizedPrompt,
+    identity.prompt.id,
+    identity.prompt.version,
+    identity.providerFingerprint,
+  ]);
+}

--- a/apps/backend/src/management/ai/prompt-descriptor.ts
+++ b/apps/backend/src/management/ai/prompt-descriptor.ts
@@ -1,0 +1,36 @@
+export interface AiPromptDescriptor {
+  id: 'endpoint-draft';
+  version: string;
+  systemPrompt: string;
+}
+
+export const activeAiPromptDescriptor: AiPromptDescriptor = {
+  id: 'endpoint-draft',
+  version: 'v1',
+  systemPrompt: `You generate API endpoint mocks.
+Return ONLY valid JSON.
+
+Schema:
+{
+  "method": "GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS",
+  "path": "/resource/path",
+  "description": "short description",
+  "statusCode": 200,
+  "responseBody": {"any":"json"},
+  "scenarios": [
+    {
+      "name": "scenario name",
+      "type": "success|error|edge-case|timeout|empty",
+      "statusCode": 200,
+      "body": {"any":"json"},
+      "delayMs": 0,
+      "weight": 1
+    }
+  ]
+}
+
+Rules:
+- path must start with '/'
+- scenarios must include at least one success and one error scenario
+- do not include markdown or explanations, only raw JSON`,
+};

--- a/apps/backend/src/management/ai/service.test.ts
+++ b/apps/backend/src/management/ai/service.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { normalizeAiDraft } from './normalize-draft.js';
 import type { AuthenticatedActor } from '../../auth/types.js';
+import { env } from '../../config/env.js';
+import { activeAiPromptDescriptor } from './prompt-descriptor.js';
 
 const authorizeProjectAccessMock = vi.fn();
 
@@ -314,6 +316,96 @@ describe('generateEndpointPreview cache', () => {
     });
 
     expect(provider.generateJson).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalida el cache cuando cambia la versión del prompt descriptor', async () => {
+    const originalVersion = activeAiPromptDescriptor.version;
+    const provider = {
+      name: 'openai',
+      generateJson: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          method: 'GET',
+          path: '/users',
+          description: 'List users',
+          statusCode: 200,
+          responseBody: [{ id: 'u1' }],
+          scenarios: [
+            {
+              name: 'success',
+              type: 'success',
+              statusCode: 200,
+              body: [{ id: 'u1' }],
+              delayMs: 0,
+              weight: 1,
+            },
+          ],
+        })
+      ),
+    } satisfies AiProvider;
+
+    try {
+      await generateEndpointPreview(actor, 'p1', 'Generate users', {
+        providers: [provider],
+        nowMs: 2_100,
+      });
+
+      activeAiPromptDescriptor.version = 'v2';
+
+      await generateEndpointPreview(actor, 'p1', 'Generate users', {
+        providers: [provider],
+        nowMs: 2_101,
+      });
+
+      expect(provider.generateJson).toHaveBeenCalledTimes(2);
+    } finally {
+      activeAiPromptDescriptor.version = originalVersion;
+    }
+  });
+
+  it('invalida el cache cuando cambia el fingerprint del modelo configurado', async () => {
+    const originalModel = env.OPENAI_MODEL;
+    const provider = {
+      name: 'openai',
+      generateJson: vi.fn().mockResolvedValue(
+        JSON.stringify({
+          method: 'GET',
+          path: '/reports',
+          description: 'List reports',
+          statusCode: 200,
+          responseBody: [],
+          scenarios: [
+            {
+              name: 'success',
+              type: 'success',
+              statusCode: 200,
+              body: [],
+              delayMs: 0,
+              weight: 1,
+            },
+          ],
+        })
+      ),
+    } satisfies AiProvider;
+
+    try {
+      env.OPENAI_MODEL = 'gpt-4.1-mini';
+
+      await generateEndpointPreview(actor, 'p1', 'Generate reports', {
+        providers: [provider],
+        nowMs: 2_200,
+      });
+
+      env.OPENAI_MODEL = 'gpt-4.1-nano';
+
+      await generateEndpointPreview(actor, 'p1', 'Generate reports', {
+        providers: [provider],
+        nowMs: 2_201,
+      });
+
+      expect(provider.generateJson).toHaveBeenCalledTimes(2);
+    } finally {
+      env.OPENAI_MODEL = originalModel;
+    }
   });
 
   it('expira entradas y permite reset explícito para pruebas determinísticas', async () => {

--- a/apps/backend/src/management/ai/service.test.ts
+++ b/apps/backend/src/management/ai/service.test.ts
@@ -1,10 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { normalizeAiDraft } from './normalize-draft.js';
 import type { AuthenticatedActor } from '../../auth/types.js';
-import { env } from '../../config/env.js';
 import { activeAiPromptDescriptor } from './prompt-descriptor.js';
 
+const mockedEnvModule = vi.hoisted(() => ({
+  env: {
+    AI_PRIMARY_PROVIDER: 'openai' as const,
+    AI_FALLBACK_PROVIDER: undefined,
+    OPENAI_MODEL: 'gpt-4.1-mini',
+  },
+}));
+
 const authorizeProjectAccessMock = vi.fn();
+
+vi.mock('../../config/env.js', () => mockedEnvModule);
 
 vi.mock('../../auth/authorization.js', () => ({
   authorizeProjectAccess: authorizeProjectAccessMock,
@@ -363,7 +372,7 @@ describe('generateEndpointPreview cache', () => {
   });
 
   it('invalida el cache cuando cambia el fingerprint del modelo configurado', async () => {
-    const originalModel = env.OPENAI_MODEL;
+    const originalModel = mockedEnvModule.env.OPENAI_MODEL;
     const provider = {
       name: 'openai',
       generateJson: vi.fn().mockResolvedValue(
@@ -388,14 +397,14 @@ describe('generateEndpointPreview cache', () => {
     } satisfies AiProvider;
 
     try {
-      env.OPENAI_MODEL = 'gpt-4.1-mini';
+      mockedEnvModule.env.OPENAI_MODEL = 'gpt-4.1-mini';
 
       await generateEndpointPreview(actor, 'p1', 'Generate reports', {
         providers: [provider],
         nowMs: 2_200,
       });
 
-      env.OPENAI_MODEL = 'gpt-4.1-nano';
+      mockedEnvModule.env.OPENAI_MODEL = 'gpt-4.1-nano';
 
       await generateEndpointPreview(actor, 'p1', 'Generate reports', {
         providers: [provider],
@@ -404,7 +413,7 @@ describe('generateEndpointPreview cache', () => {
 
       expect(provider.generateJson).toHaveBeenCalledTimes(2);
     } finally {
-      env.OPENAI_MODEL = originalModel;
+      mockedEnvModule.env.OPENAI_MODEL = originalModel;
     }
   });
 

--- a/apps/backend/src/management/ai/service.ts
+++ b/apps/backend/src/management/ai/service.ts
@@ -2,7 +2,13 @@ import type { AuthenticatedActor } from '../../auth/types.js';
 import type { Env } from '../../config/env.js';
 import { toPrismaJson } from '../../lib/prisma-json.js';
 import { AppError } from '../../middleware/error-handler.js';
+import {
+  buildAiExecutionIdentity,
+  buildAiPreviewCacheKey,
+  type AiExecutionIdentity,
+} from './execution-identity.js';
 import { normalizeAiDraft } from './normalize-draft.js';
+import { activeAiPromptDescriptor } from './prompt-descriptor.js';
 import { AiProviderExecutionError, resolveAiProviderChain, type AiProvider } from './provider.js';
 import { createCompatAiProvider } from './providers/compat.js';
 import { createOpenAiProvider } from './providers/openai.js';
@@ -14,33 +20,6 @@ import {
   type AiPreviewResponseInput,
   type AiRawGeneratedEndpointInput,
 } from './schema.js';
-
-const SYSTEM_PROMPT = `You generate API endpoint mocks.
-Return ONLY valid JSON.
-
-Schema:
-{
-  "method": "GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS",
-  "path": "/resource/path",
-  "description": "short description",
-  "statusCode": 200,
-  "responseBody": {"any":"json"},
-  "scenarios": [
-    {
-      "name": "scenario name",
-      "type": "success|error|edge-case|timeout|empty",
-      "statusCode": 200,
-      "body": {"any":"json"},
-      "delayMs": 0,
-      "weight": 1
-    }
-  ]
-}
-
-Rules:
-- path must start with '/'
-- scenarios must include at least one success and one error scenario
-- do not include markdown or explanations, only raw JSON`;
 
 class AiShapeValidationError extends Error {
   constructor(message: string) {
@@ -72,14 +51,6 @@ function clonePreviewValue(value: AiPreviewResponseInput): AiPreviewResponseInpu
   return aiPreviewResponseSchema.parse(structuredClone(value));
 }
 
-function normalizePreviewCachePrompt(prompt: string): string {
-  return prompt.trim();
-}
-
-function buildPreviewCacheKey(projectId: string, prompt: string): string {
-  return `${projectId}:${normalizePreviewCachePrompt(prompt)}`;
-}
-
 function pruneExpiredPreviewCacheEntries(nowMs: number): void {
   for (const [key, entry] of previewCache.entries()) {
     if (entry.expiresAtMs <= nowMs) {
@@ -101,13 +72,12 @@ function evictPreviewCacheEntriesIfNeeded(): void {
 }
 
 function readPreviewCache(
-  projectId: string,
-  prompt: string,
+  identity: AiExecutionIdentity,
   nowMs: number
 ): AiPreviewResponseInput | null {
   pruneExpiredPreviewCacheEntries(nowMs);
 
-  const entry = previewCache.get(buildPreviewCacheKey(projectId, prompt));
+  const entry = previewCache.get(buildAiPreviewCacheKey(identity));
 
   if (!entry) {
     return null;
@@ -117,8 +87,7 @@ function readPreviewCache(
 }
 
 function writePreviewCache(
-  projectId: string,
-  prompt: string,
+  identity: AiExecutionIdentity,
   value: AiPreviewResponseInput,
   nowMs: number
 ): AiPreviewResponseInput {
@@ -127,7 +96,7 @@ function writePreviewCache(
 
   const clonedValue = clonePreviewValue(value);
 
-  previewCache.set(buildPreviewCacheKey(projectId, prompt), {
+  previewCache.set(buildAiPreviewCacheKey(identity), {
     value: clonedValue,
     expiresAtMs: nowMs + AI_PREVIEW_CACHE_TTL_MS,
   });
@@ -204,15 +173,13 @@ async function getEnv(): Promise<Env> {
   return env;
 }
 
-async function buildAiProviders(): Promise<AiProvider[]> {
-  const env = await getEnv();
-
+function buildAiProviders(env: Env): AiProvider[] {
   return resolveAiProviderChain(env).map((providerName) => {
     if (providerName === 'compat') {
-      return createCompatAiProvider(env, { systemPrompt: SYSTEM_PROMPT });
+      return createCompatAiProvider(env, { systemPrompt: activeAiPromptDescriptor.systemPrompt });
     }
 
-    return createOpenAiProvider(env, { systemPrompt: SYSTEM_PROMPT });
+    return createOpenAiProvider(env, { systemPrompt: activeAiPromptDescriptor.systemPrompt });
   });
 }
 
@@ -237,7 +204,7 @@ export async function createNormalizedDraftWithFallback(
   prompt: string,
   providers?: AiProvider[]
 ): Promise<AiPreviewResponseInput> {
-  const activeProviders = providers ?? (await buildAiProviders());
+  const activeProviders = providers ?? buildAiProviders(await getEnv());
 
   if (activeProviders.length === 0) {
     throw createAiMissingConfigError('No AI providers are configured');
@@ -358,15 +325,20 @@ export async function generateEndpointPreview(
 ) {
   await authorizeAiProjectMutation(actor, projectId);
 
+  const env = await getEnv();
+  const identity = buildAiExecutionIdentity(env, projectId, prompt, activeAiPromptDescriptor);
   const nowMs = runtimeOptions.nowMs ?? Date.now();
-  const cachedPreview = readPreviewCache(projectId, prompt, nowMs);
+  const cachedPreview = readPreviewCache(identity, nowMs);
 
   if (cachedPreview) {
     return cachedPreview;
   }
 
-  const preview = await generateNormalizedDraft(prompt, runtimeOptions.providers);
-  return writePreviewCache(projectId, prompt, preview, nowMs);
+  const preview = await generateNormalizedDraft(
+    identity.normalizedPrompt,
+    runtimeOptions.providers
+  );
+  return writePreviewCache(identity, preview, nowMs);
 }
 
 export async function generateEndpointWithAi(
@@ -376,7 +348,13 @@ export async function generateEndpointWithAi(
 ) {
   await authorizeAiProjectMutation(actor, projectId);
 
-  const previewDraft = await generateNormalizedDraft(prompt);
+  const identity = buildAiExecutionIdentity(
+    await getEnv(),
+    projectId,
+    prompt,
+    activeAiPromptDescriptor
+  );
+  const previewDraft = await generateNormalizedDraft(identity.normalizedPrompt);
   return persistGeneratedEndpoint(projectId, toPersistedDraft(previewDraft));
 }
 


### PR DESCRIPTION
Closes #63

## Summary
- add an explicit backend prompt descriptor with id/version for the current AI generation flow
- centralize AI execution identity so preview cache keys depend on prompt version and provider/model fingerprint
- cover prompt-version and model-fingerprint cache invalidation plus shared prompt provenance with focused backend tests

## Changes
| File | Change |
|------|--------|
| `apps/backend/src/management/ai/prompt-descriptor.ts` | Added the active backend prompt descriptor with stable id/version |
| `apps/backend/src/management/ai/execution-identity.ts` | Added centralized prompt normalization, provider fingerprinting, execution identity, and preview cache-key construction |
| `apps/backend/src/management/ai/execution-identity.test.ts` | Added focused helper tests for deterministic identity fields |
| `apps/backend/src/management/ai/service.ts` | Switched AI preview cache handling and execution wiring to the shared identity builder |
| `apps/backend/src/management/ai/service.test.ts` | Added unit coverage for cache invalidation on prompt version and model changes |
| `apps/backend/src/__tests__/app.integration.test.ts` | Added integration proof for unchanged `{ prompt }` HTTP payload and shared prompt provenance across preview/generate |

## PR Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Test Plan
- [x] Focused strict-TDD verify rerun passed for `issue-63-prompt-versioning` (70/70 tests, lint clean, typecheck clean)
- [x] `pnpm --dir apps/backend exec vitest run src/management/ai/execution-identity.test.ts --reporter=verbose`
- [x] `pnpm --dir apps/backend exec vitest run src/__tests__/app.integration.test.ts -t "POST /api/v1/projects/:projectId/endpoints/ai-preview|POST /api/v1/projects/:projectId/endpoints/ai-generate ignora previews cacheados y persiste por su flujo normal" --reporter=verbose`
- [ ] Manual exploratory testing

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts were modified, so shellcheck was not needed
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers
- [ ] Docs updated if behavior changed
