### PR TITLE
feat(workspace): add sidebar identity and workspace members area

### DIFF
--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.css
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.css
@@ -341,3 +341,81 @@
   font-size: 0.75rem;
   color: var(--cp-text-subtle);
 }
+
+.sidebar__user-card {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-shrink: 0;
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--cp-border-default);
+  background: var(--cp-surface-raised);
+}
+
+.sidebar__user-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 1px solid var(--cp-border-default);
+  flex-shrink: 0;
+}
+
+.sidebar__user-avatar--fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--cp-accent-on-primary);
+  background: var(--cp-accent-primary);
+}
+
+.sidebar__user-details {
+  min-width: 0;
+}
+
+.sidebar__user-name {
+  margin: 0.125rem 0 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--cp-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar__footer-actions {
+  flex-shrink: 0;
+  margin-top: 0.75rem;
+}
+
+.sidebar__sign-out-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  width: 100%;
+  min-height: 42px;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--cp-border-default);
+  border-radius: 10px;
+  background: var(--cp-surface-raised);
+  color: var(--cp-text-body);
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sidebar__sign-out-btn svg {
+  flex-shrink: 0;
+}
+
+.sidebar__sign-out-btn:hover {
+  background: var(--cp-surface-subtle);
+  border-color: var(--cp-border-input-hover);
+}

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.html
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.html
@@ -119,6 +119,15 @@
         <svg lucideHistory [size]="18" strokeWidth="1.75"></svg>
         <span>History</span>
       </button>
+      <button
+        type="button"
+        class="sidebar__nav-item"
+        [class.sidebar__nav-item--active]="activeNav() === 'workspace'"
+        (click)="selectNav('workspace')"
+      >
+        <svg lucideUsers [size]="18" strokeWidth="1.75"></svg>
+        <span>Workspace</span>
+      </button>
     </nav>
   </div>
 
@@ -134,5 +143,28 @@
       </div>
       <p class="sidebar__meta">{{ ap.endpointCount }} endpoints</p>
     </section>
+  }
+
+  @if (normalizedUserDisplayName(); as userDisplayName) {
+    <section class="sidebar__user-card" aria-label="Signed-in user">
+      @if (normalizedUserAvatarUrl(); as avatarUrl) {
+        <img class="sidebar__user-avatar" [src]="avatarUrl" [alt]="'Avatar of ' + userDisplayName" />
+      } @else {
+        <span class="sidebar__user-avatar sidebar__user-avatar--fallback" aria-hidden="true">{{ userInitials() }}</span>
+      }
+      <div class="sidebar__user-details">
+        <p class="sidebar__label sidebar__label--card">Signed in as</p>
+        <p class="sidebar__user-name">{{ userDisplayName }}</p>
+      </div>
+    </section>
+  }
+
+  @if (showSignOut()) {
+    <div class="sidebar__footer-actions">
+      <button type="button" class="sidebar__sign-out-btn" (click)="signOut()">
+        <svg lucideLogOut [size]="18" strokeWidth="1.75" aria-hidden="true"></svg>
+        <span>Sign out</span>
+      </button>
+    </div>
   }
 </aside>

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.spec.ts
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.spec.ts
@@ -1,0 +1,122 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveAngularExternalResources, setupAngularVitest } from '../../../../testing/angular-vitest';
+import { MainDashboardSidebarComponent } from './main-dashboard-sidebar.component';
+
+setupAngularVitest();
+
+const projectFixture = {
+  id: 'project-1',
+  name: 'Workspace API',
+  mockUrl: 'https://mock.example.com/workspace-api',
+  endpointCount: 12,
+};
+
+async function renderComponent(options?: {
+  showSignOut?: boolean;
+  userDisplayName?: string | null;
+  userAvatarUrl?: string | null;
+}) {
+  await resolveAngularExternalResources();
+  await TestBed.configureTestingModule({
+    imports: [MainDashboardSidebarComponent],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(MainDashboardSidebarComponent);
+  const component = fixture.componentInstance as unknown as {
+    projects: () => (typeof projectFixture)[];
+    selectedProjectId: () => string;
+    activeNav: () => 'dashboard' | 'logs' | 'endpoints' | 'history' | 'workspace';
+    showSignOut: () => boolean;
+    userDisplayName: () => string | null;
+    userAvatarUrl: () => string | null;
+  };
+  component.projects = () => [projectFixture];
+  component.selectedProjectId = () => projectFixture.id;
+  component.activeNav = () => 'dashboard';
+  component.showSignOut = () => options?.showSignOut ?? true;
+  component.userDisplayName = () => options?.userDisplayName ?? null;
+  component.userAvatarUrl = () => options?.userAvatarUrl ?? null;
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+
+  return fixture;
+}
+
+describe('MainDashboardSidebarComponent', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a sign out action in the sidebar footer when requested', async () => {
+    const fixture = await renderComponent();
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('.sidebar__sign-out-btn')?.textContent).toContain('Sign out');
+  });
+
+  it('emits signOutRequested when the sidebar sign out button is clicked', async () => {
+    const fixture = await renderComponent();
+    const component = fixture.componentInstance;
+    const emitSpy = vi.fn();
+    component.signOutRequested.subscribe(emitSpy);
+
+    (fixture.nativeElement as HTMLElement).querySelector<HTMLButtonElement>('.sidebar__sign-out-btn')?.click();
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the sign out action when the shell disables it', async () => {
+    const fixture = await renderComponent({ showSignOut: false });
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('.sidebar__sign-out-btn')).toBeNull();
+  });
+
+  it('renders a Workspace navigation entry alongside the existing app sections', async () => {
+    const fixture = await renderComponent();
+    const element = fixture.nativeElement as HTMLElement;
+    const navLabels = Array.from(element.querySelectorAll('.sidebar__nav-item span')).map(
+      (span) => span.textContent?.trim() ?? '',
+    );
+
+    expect(navLabels).toEqual(['Dashboard', 'Endpoints', 'Logs', 'History', 'Workspace']);
+  });
+
+  it('emits navSelect with "workspace" when the user activates the Workspace entry', async () => {
+    const fixture = await renderComponent();
+    const component = fixture.componentInstance;
+    const emitSpy = vi.fn();
+    component.navSelect.subscribe(emitSpy);
+
+    const buttons = (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLButtonElement>('.sidebar__nav-item');
+    const workspaceButton = Array.from(buttons).find((btn) => btn.textContent?.trim().includes('Workspace'));
+    workspaceButton?.click();
+
+    expect(emitSpy).toHaveBeenCalledWith('workspace');
+  });
+
+  it('renders the signed-in user block with avatar and name', async () => {
+    const fixture = await renderComponent({
+      userDisplayName: 'Owner User',
+      userAvatarUrl: 'https://cdn.example.com/avatar.png',
+    });
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('.sidebar__user-name')?.textContent).toContain('Owner User');
+    expect(element.querySelector('.sidebar__user-avatar')?.getAttribute('src')).toBe(
+      'https://cdn.example.com/avatar.png',
+    );
+  });
+
+  it('renders fallback initials when the user has no avatar URL', async () => {
+    const fixture = await renderComponent({
+      userDisplayName: 'Owner User',
+      userAvatarUrl: null,
+    });
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('.sidebar__user-avatar--fallback')?.textContent?.trim()).toBe('OU');
+  });
+});

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.ts
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.ts
@@ -6,7 +6,9 @@ import {
   LucideHandMetal,
   LucideHistory,
   LucideLayoutGrid,
+  LucideLogOut,
   LucidePlus,
+  LucideUsers,
 } from '@lucide/angular';
 
 import type {
@@ -27,7 +29,9 @@ import type {
     LucideCopy,
     LucideFileText,
     LucideLayoutGrid,
+    LucideLogOut,
     LucidePlus,
+    LucideUsers,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -35,6 +39,9 @@ export class MainDashboardSidebarComponent {
   readonly projects = input.required<SidebarProjectRow[]>();
   readonly selectedProjectId = input.required<string>();
   readonly activeNav = input.required<WorkspaceNavId>();
+  readonly showSignOut = input(false);
+  readonly userDisplayName = input<string | null>(null);
+  readonly userAvatarUrl = input<string | null>(null);
   readonly loading = input(false);
   readonly errorMessage = input<string | null>(null);
   readonly pagination = input<SidebarProjectPaginationState>({
@@ -50,12 +57,13 @@ export class MainDashboardSidebarComponent {
   readonly createProjectRequested = output<void>();
   readonly retryRequested = output<void>();
   readonly loadMoreRequested = output<void>();
+  readonly signOutRequested = output<void>();
 
   protected readonly activeProject = computed((): SidebarProjectRow | null => {
     const list = this.projects();
     if (!list.length) return null;
     const id = this.selectedProjectId();
-    return list.find((p) => p.id === id) ?? list[0]!;
+    return list.find((p) => p.id === id) ?? list[0] ?? null;
   });
 
   protected readonly displayMockUrl = computed(() => {
@@ -64,6 +72,31 @@ export class MainDashboardSidebarComponent {
     const url = ap.mockUrl;
     const max = 20;
     return url.length <= max ? url : `${url.slice(0, max)}...`;
+  });
+
+  protected readonly normalizedUserDisplayName = computed(() => {
+    const displayName = this.userDisplayName();
+    if (!displayName) return null;
+    const trimmed = displayName.trim();
+    return trimmed.length ? trimmed : null;
+  });
+
+  protected readonly normalizedUserAvatarUrl = computed(() => {
+    const avatarUrl = this.userAvatarUrl();
+    if (!avatarUrl) return null;
+    const trimmed = avatarUrl.trim();
+    return trimmed.length ? trimmed : null;
+  });
+
+  protected readonly userInitials = computed(() => {
+    const displayName = this.normalizedUserDisplayName();
+    if (!displayName) return '?';
+    const words = displayName.split(/\s+/).filter(Boolean);
+    if (words.length === 1) return (words[0] ?? '').slice(0, 2).toUpperCase();
+    return words
+      .slice(0, 2)
+      .map((word) => word[0]?.toUpperCase() ?? '')
+      .join('');
   });
 
   protected selectProject(id: string): void {
@@ -90,5 +123,9 @@ export class MainDashboardSidebarComponent {
     const ap = this.activeProject();
     if (!ap) return;
     void navigator.clipboard.writeText(ap.mockUrl);
+  }
+
+  protected signOut(): void {
+    this.signOutRequested.emit();
   }
 }

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.css
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.css
@@ -30,19 +30,8 @@
   flex-shrink: 0;
 }
 
-/* Fills space between quick actions and global config; activity card grows inside */
-.utility__section--activity {
-  flex: 1 1 auto;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-.utility__section--activity .utility__label {
-  flex-shrink: 0;
-}
-
 .utility__section--footer {
+  margin-top: auto;
   flex-shrink: 0;
 }
 
@@ -86,6 +75,20 @@
   border-color: var(--cp-border-input-hover);
 }
 
+.utility__action--featured {
+  border-color: color-mix(in srgb, var(--cp-accent-primary) 40%, var(--cp-border-default));
+  background: color-mix(in srgb, var(--cp-accent-primary) 8%, var(--cp-surface-raised));
+}
+
+.utility__action--featured:hover {
+  border-color: color-mix(in srgb, var(--cp-accent-primary) 60%, var(--cp-border-input-hover));
+  background: color-mix(in srgb, var(--cp-accent-primary) 12%, var(--cp-surface-overlay));
+}
+
+.utility__action--featured .utility__action-icon {
+  background: color-mix(in srgb, var(--cp-accent-primary) 16%, var(--cp-surface-app));
+}
+
 .utility__action:focus-visible {
   outline: 2px solid var(--cp-accent-focus-outline);
   outline-offset: 2px;
@@ -95,6 +98,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  align-self: center;
   width: 36px;
   height: 36px;
   border-radius: 8px;
@@ -123,117 +127,6 @@
   line-height: 1.35;
 }
 
-/* RecentActivity: stretches with column; list scrolls only if needed */
-.utility__activity-card {
-  flex: 1;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  border-radius: 12px;
-  border: 1px solid var(--cp-border-default);
-  background: var(--cp-surface-raised);
-  overflow: hidden;
-}
-
-.utility__activity-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-}
-
-.utility__activity-row {
-  display: flex;
-  align-items: flex-start;
-  gap: 0.75rem;
-  padding: 0.875rem 1rem;
-  border-bottom: 1px solid var(--cp-border-muted);
-}
-
-.utility__activity-row:last-child {
-  border-bottom: none;
-}
-
-.utility__activity-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  background: var(--cp-surface-app);
-  border: 1px solid var(--cp-border-muted);
-  color: var(--cp-text-icon-muted);
-}
-
-.utility__activity-body {
-  min-width: 0;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
-  padding-top: 0.125rem;
-}
-
-.utility__activity-primary {
-  margin: 0;
-  font-size: 0.8125rem;
-  line-height: 1.45;
-  color: var(--cp-text-body);
-}
-
-.utility__activity-verb {
-  margin-right: 0.35em;
-  font-weight: 500;
-  text-transform: lowercase;
-}
-
-.utility__activity-verb[data-tone='create'] {
-  color: var(--cp-accent-primary);
-}
-
-.utility__activity-verb[data-tone='add'] {
-  color: var(--cp-activity-verb-add);
-}
-
-.utility__activity-verb[data-tone='update'] {
-  color: var(--cp-activity-verb-update);
-}
-
-.utility__activity-target {
-  font-weight: 600;
-  color: var(--cp-text-primary);
-  letter-spacing: -0.01em;
-}
-
-.utility__activity-meta {
-  margin: 0;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.25rem 0.35rem;
-  font-size: 0.6875rem;
-  line-height: 1.3;
-}
-
-.utility__activity-meta-icon {
-  flex-shrink: 0;
-  color: var(--cp-text-subtle);
-  opacity: 0.85;
-}
-
-.utility__activity-time {
-  color: var(--cp-text-muted);
-}
-
-.utility__activity-by {
-  color: var(--cp-text-subtle);
-}
-
 .utility__config-card {
   display: flex;
   flex-direction: column;
@@ -242,7 +135,6 @@
   border-radius: 12px;
   background: var(--cp-surface-raised);
   border: 1px solid var(--cp-border-default);
-  /* flex: 1; */
 }
 
 .utility__members-card {

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.html
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.html
@@ -1,12 +1,13 @@
 <aside class="utility" aria-label="Acciones y configuración">
   <section class="utility__section" aria-labelledby="utility-quick-heading">
     <h2 id="utility-quick-heading" class="utility__label">Quick actions</h2>
-    <ul class="utility__actions" role="list">
+    <ul class="utility__actions">
       @for (action of quickActions; track action.id) {
         <li>
           <button
             type="button"
             class="utility__action"
+            [class.utility__action--featured]="action.featured"
             [disabled]="action.disabled === true || (!canMutate() && action.id !== 'test' && action.id !== 'export')"
             [attr.aria-disabled]="
               action.disabled === true || (!canMutate() && action.id !== 'test' && action.id !== 'export')
@@ -15,23 +16,36 @@
             (click)="onQuickAction(action.id)"
           >
             <span class="utility__action-icon" aria-hidden="true">
-              @switch (action.icon) {
-                @case ('sparkles') {
-                  <svg lucideSparkles [size]="18" strokeWidth="1.75"></svg>
-                }
-                @case ('plus') {
-                  <svg lucidePlus [size]="18" strokeWidth="1.75"></svg>
-                }
-                @case ('play') {
-                  <svg lucidePlay [size]="18" strokeWidth="1.75"></svg>
-                }
-                @case ('download') {
-                  <svg lucideDownload [size]="18" strokeWidth="1.75"></svg>
-                }
-                @case ('upload') {
-                  <svg lucideUpload [size]="18" strokeWidth="1.75"></svg>
-                }
-              }
+              <svg
+                lucideSparkles
+                [size]="18"
+                strokeWidth="1.75"
+                [style.display]="action.icon === 'sparkles' ? null : 'none'"
+              ></svg>
+              <svg
+                lucidePlus
+                [size]="18"
+                strokeWidth="1.75"
+                [style.display]="action.icon === 'plus' ? null : 'none'"
+              ></svg>
+              <svg
+                lucidePlay
+                [size]="18"
+                strokeWidth="1.75"
+                [style.display]="action.icon === 'play' ? null : 'none'"
+              ></svg>
+              <svg
+                lucideDownload
+                [size]="18"
+                strokeWidth="1.75"
+                [style.display]="action.icon === 'download' ? null : 'none'"
+              ></svg>
+              <svg
+                lucideUpload
+                [size]="18"
+                strokeWidth="1.75"
+                [style.display]="action.icon === 'upload' ? null : 'none'"
+              ></svg>
             </span>
             <span class="utility__action-text">
               <span class="utility__action-title">{{ action.title }}</span>
@@ -43,116 +57,10 @@
     </ul>
   </section>
 
-  <section class="utility__section utility__section--activity" aria-labelledby="utility-activity-heading">
-    <h2 id="utility-activity-heading" class="utility__label">Recent requests</h2>
-    <div class="utility__activity-card">
-      @if (recentRequests().length > 0) {
-        <ul class="utility__activity-list cp-scrollbar" role="list">
-          @for (item of recentRequests(); track item.id) {
-            <li class="utility__activity-row">
-              <span class="utility__activity-icon" aria-hidden="true">
-                <svg lucideGitBranch [size]="16" strokeWidth="1.75"></svg>
-              </span>
-              <div class="utility__activity-body">
-                <p class="utility__activity-primary">
-                  <strong class="utility__activity-target">{{ item.requestLabel }}</strong>
-                </p>
-                <p class="utility__activity-meta">
-                  <svg
-                    lucideClock
-                    [size]="12"
-                    strokeWidth="1.75"
-                    class="utility__activity-meta-icon"
-                    aria-hidden="true"
-                  ></svg>
-                  <span class="utility__activity-time">{{ item.timeLabel }}</span>
-                  <span>{{ item.statusCode }}</span>
-                  <span>{{ item.latencyMs }}ms</span>
-                  <span>{{ item.scenarioType }}</span>
-                </p>
-              </div>
-            </li>
-          }
-        </ul>
-      } @else {
-        <p class="utility__activity-empty">No recent requests yet.</p>
-      }
-    </div>
-  </section>
-
-  <section class="utility__section" aria-labelledby="utility-members-heading">
-    <h2 id="utility-members-heading" class="utility__label">Workspace members</h2>
-    <div class="utility__config-card utility__members-card">
-      <div class="utility__members-header">
-        <span class="utility__members-role">Your role: {{ workspaceRoleLabel() }}</span>
-      </div>
-
-      @if (workspaceMembersError()) {
-        <p class="utility__members-error">{{ workspaceMembersError() }}</p>
-      }
-
-      @if (workspaceMembersLoading()) {
-        <p class="utility__activity-empty">Loading members…</p>
-      } @else if (workspaceMembers().length > 0) {
-        <ul class="utility__members-list" role="list">
-          @for (member of workspaceMembers(); track member.userId) {
-            <li class="utility__members-row">
-              <div class="utility__members-meta">
-                <strong>{{ member.displayName || member.email || member.userId }}</strong>
-                <span>{{ member.email || 'No email' }} · {{ member.role }}</span>
-              </div>
-              @if (canManageMembers()) {
-                <button
-                  type="button"
-                  class="utility__members-remove"
-                  [disabled]="workspaceMemberMutationPending()"
-                  (click)="onRemoveMember(member.userId)"
-                >
-                  Remove
-                </button>
-              }
-            </li>
-          }
-        </ul>
-      } @else {
-        <p class="utility__activity-empty">No workspace members yet.</p>
-      }
-
-      @if (canManageMembers()) {
-        <form
-          class="utility__members-form"
-          #memberForm="ngForm"
-          (ngSubmit)="addMember(memberEmail.value, memberRole.value); memberForm.resetForm({ role: 'viewer' })"
-        >
-          <input
-            #memberEmail
-            type="email"
-            name="email"
-            required
-            placeholder="colleague@example.com"
-            class="utility__members-input"
-          />
-          <select #memberRole name="role" class="utility__members-select">
-            <option value="viewer">Viewer</option>
-            <option value="editor">Editor</option>
-            <option value="owner">Owner</option>
-          </select>
-          <button
-            type="submit"
-            class="utility__config-btn"
-            [disabled]="workspaceMemberMutationPending() || !memberForm.form.valid"
-          >
-            Add member
-          </button>
-        </form>
-      }
-    </div>
-  </section>
-
   <section class="utility__section utility__section--footer" aria-labelledby="utility-global-heading">
     <h2 id="utility-global-heading" class="utility__label">Global config</h2>
     <div class="utility__config-card">
-      <ul class="utility__config-rows" role="list">
+      <ul class="utility__config-rows">
         @for (row of globalConfigRows(); track row.label) {
           <li class="utility__config-row">
             <span class="utility__config-key">{{ row.label }}</span>

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.spec.ts
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.spec.ts
@@ -7,14 +7,6 @@ import { MainDashboardUtilitySidebarComponent } from './main-dashboard-utility-s
 setupAngularVitest();
 
 type MainDashboardUtilityHarness = MainDashboardUtilitySidebarComponent & {
-  recentRequests: () => Array<{
-    id: string;
-    requestLabel: string;
-    statusCode: number;
-    latencyMs: number;
-    scenarioType: string;
-    timeLabel: string;
-  }>;
   globalConfigRows: () => Array<{ label: string; badge: string; tone: 'neutral' | 'success' }>;
   quickActions: Array<{ id: string; title: string; subtitle: string }>;
   onQuickAction(id: string): void;
@@ -82,7 +74,7 @@ const projectFixture: DashboardProject = {
 };
 
 describe('MainDashboardUtilitySidebarComponent', () => {
-  it('derives recent request traffic and persisted config badges instead of seeded placeholder activity', () => {
+  it('derives persisted config badges for the global config section', () => {
     const injector = Injector.create({ providers: [...provideAngularReactiveSchedulers()] });
     const component = runInInjectionContext(
       injector,
@@ -91,34 +83,12 @@ describe('MainDashboardUtilitySidebarComponent', () => {
 
     bindProjectInput(component, projectFixture);
 
-    expect(component.recentRequests()).toEqual([
-      {
-        id: 'log-1',
-        requestLabel: 'POST /users',
-        statusCode: 500,
-        latencyMs: 140,
-        scenarioType: 'error',
-        timeLabel: 'just now',
-      },
-    ]);
     expect(component.globalConfigRows()).toEqual([
       { label: 'Default latency', badge: '50–250ms', tone: 'neutral' },
       { label: 'Error simulation', badge: '15% · 400, 500', tone: 'success' },
       { label: 'Rate limiting', badge: '90 req/min', tone: 'neutral' },
       { label: 'Logging', badge: 'Full', tone: 'neutral' },
     ]);
-  });
-
-  it('keeps recent request traffic empty when the summary has no traffic yet', () => {
-    const injector = Injector.create({ providers: [...provideAngularReactiveSchedulers()] });
-    const component = runInInjectionContext(
-      injector,
-      () => new MainDashboardUtilitySidebarComponent(),
-    ) as unknown as MainDashboardUtilityHarness & { project: () => DashboardProject };
-
-    bindProjectInput(component, { ...projectFixture, recentRequests: [] });
-
-    expect(component.recentRequests()).toEqual([]);
   });
 
   it('adds a create snapshot quick action gated through the mutation affordance', () => {

--- a/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.ts
+++ b/apps/web/src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.ts
@@ -1,34 +1,14 @@
 import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import {
-  LucideClock,
-  LucideDownload,
-  LucideGitBranch,
-  LucidePlay,
-  LucidePlus,
-  LucideSparkles,
-  LucideSettings,
-  LucideUpload,
-} from '@lucide/angular';
+import { LucideDownload, LucidePlay, LucidePlus, LucideSparkles, LucideSettings, LucideUpload } from '@lucide/angular';
 
 import type { DashboardProject } from '../../models/dashboard-project.model';
-import type { WorkspaceRoleDto } from '../../../../shared/http/api.types';
-import type { WorkspaceMember } from '../../../workspace-members/models/workspace-member.model';
-
-export interface UtilitySidebarRequestItem {
-  id: string;
-  requestLabel: string;
-  statusCode: number;
-  latencyMs: number;
-  scenarioType: string;
-  timeLabel: string;
-}
 
 interface UtilityQuickAction {
   id: 'create' | 'create-manual' | 'snapshot' | 'test' | 'export' | 'import';
   title: string;
   subtitle: string;
   icon: 'plus' | 'play' | 'download' | 'upload' | 'sparkles';
+  featured?: boolean;
   disabled?: boolean;
 }
 
@@ -37,26 +17,12 @@ interface UtilityQuickAction {
   templateUrl: './main-dashboard-utility-sidebar.component.html',
   styleUrls: ['./main-dashboard-utility-sidebar.component.css'],
   standalone: true,
-  imports: [
-    FormsModule,
-    LucideClock,
-    LucideDownload,
-    LucideGitBranch,
-    LucidePlay,
-    LucidePlus,
-    LucideSparkles,
-    LucideSettings,
-    LucideUpload,
-  ],
+  imports: [LucideDownload, LucidePlay, LucidePlus, LucideSparkles, LucideSettings, LucideUpload],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MainDashboardUtilitySidebarComponent {
   readonly project = input.required<DashboardProject>();
   readonly canMutate = input(true);
-  readonly workspaceMembers = input<WorkspaceMember[]>([]);
-  readonly workspaceMembersLoading = input(false);
-  readonly workspaceMembersError = input<string | null>(null);
-  readonly workspaceMemberMutationPending = input(false);
 
   readonly createEndpoint = output<void>();
   readonly createManualEndpoint = output<void>();
@@ -65,8 +31,6 @@ export class MainDashboardUtilitySidebarComponent {
   readonly exportConfig = output<void>();
   readonly importEndpoints = output<void>();
   readonly editGlobalConfig = output<void>();
-  readonly addWorkspaceMember = output<{ email: string; role: WorkspaceRoleDto }>();
-  readonly removeWorkspaceMember = output<string>();
 
   protected readonly quickActions: UtilityQuickAction[] = [
     {
@@ -74,6 +38,7 @@ export class MainDashboardUtilitySidebarComponent {
       title: 'Create endpoint with AI',
       subtitle: 'Add a new mock endpoint',
       icon: 'sparkles' as const,
+      featured: true,
     },
     {
       id: 'create-manual',
@@ -108,29 +73,27 @@ export class MainDashboardUtilitySidebarComponent {
     },
   ];
 
-  protected readonly recentRequests = computed((): UtilitySidebarRequestItem[] =>
-    this.project().recentRequests.map((request) => ({
-      id: request.id,
-      requestLabel: `${request.method} ${request.path}`,
-      statusCode: request.statusCode,
-      latencyMs: request.latencyMs,
-      scenarioType: request.scenarioType,
-      timeLabel: request.timeLabel,
-    })),
-  );
-
   protected readonly globalConfigRows = computed(() => {
     const config = this.project().configSummary;
+    let defaultLatencyBadge = 'Disabled';
+    if (config.latency.enabled) {
+      defaultLatencyBadge =
+        config.latency.mode === 'range'
+          ? `${config.latency.minMs}–${config.latency.maxMs}ms`
+          : `${config.latency.maxMs}ms`;
+    }
+    let loggingBadge: 'Full' | 'Off' | 'Basic' = 'Basic';
+    if (config.logging.level === 'full') {
+      loggingBadge = 'Full';
+    } else if (config.logging.level === 'off') {
+      loggingBadge = 'Off';
+    }
 
     return [
       {
         label: 'Default latency',
-        badge: config.latency.enabled
-          ? config.latency.mode === 'range'
-            ? `${config.latency.minMs}–${config.latency.maxMs}ms`
-            : `${config.latency.maxMs}ms`
-          : 'Disabled',
-        tone: config.latency.enabled ? ('neutral' as const) : ('neutral' as const),
+        badge: defaultLatencyBadge,
+        tone: 'neutral' as const,
       },
       {
         label: 'Error simulation',
@@ -146,39 +109,11 @@ export class MainDashboardUtilitySidebarComponent {
       },
       {
         label: 'Logging',
-        badge: config.logging.level === 'full' ? 'Full' : config.logging.level === 'off' ? 'Off' : 'Basic',
+        badge: loggingBadge,
         tone: 'neutral' as const,
       },
     ];
   });
-
-  protected readonly workspaceRoleLabel = computed(() => {
-    switch (this.project().workspace.role) {
-      case 'owner':
-        return 'Owner';
-      case 'editor':
-        return 'Editor';
-      default:
-        return 'Viewer';
-    }
-  });
-
-  protected readonly canManageMembers = computed(() => this.project().workspace.capabilities.canManageMembers);
-
-  protected addMember(email: string, role: string): void {
-    if (!this.canManageMembers() || this.workspaceMemberMutationPending()) return;
-
-    const normalizedEmail = email.trim();
-    if (!normalizedEmail) return;
-
-    const nextRole: WorkspaceRoleDto = role === 'owner' || role === 'editor' ? role : 'viewer';
-    this.addWorkspaceMember.emit({ email: normalizedEmail, role: nextRole });
-  }
-
-  protected onRemoveMember(memberUserId: string): void {
-    if (!this.canManageMembers() || this.workspaceMemberMutationPending()) return;
-    this.removeWorkspaceMember.emit(memberUserId);
-  }
 
   protected onQuickAction(id: string): void {
     const action = this.quickActions.find((item) => item.id === id);

--- a/apps/web/src/app/features/main-dashboard/models/dashboard-project.model.ts
+++ b/apps/web/src/app/features/main-dashboard/models/dashboard-project.model.ts
@@ -73,6 +73,7 @@ export interface DashboardEndpointRowsMeta {
 export interface DashboardWorkspaceSummary {
   id: string;
   role: WorkspaceRoleDto;
+  isPersonal?: boolean;
   capabilities: WorkspaceCapabilitiesDto;
 }
 

--- a/apps/web/src/app/features/workspace-members/workspace-members-page.component.css
+++ b/apps/web/src/app/features/workspace-members/workspace-members-page.component.css
@@ -1,0 +1,284 @@
+:host {
+  display: contents;
+}
+
+.workspace-members-page {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--cp-border-muted);
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.workspace-members-page__head {
+  padding: 1.5rem 1.5rem 1rem;
+  flex-shrink: 0;
+}
+
+.workspace-members-page__head-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.workspace-members-page__titles {
+  min-width: 0;
+}
+
+.workspace-members-page__title {
+  margin: 0 0 0.25rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--cp-text-primary);
+}
+
+.workspace-members-page__sub {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--cp-text-subtle);
+}
+
+.workspace-members-page__sub strong {
+  color: var(--cp-text-body);
+  font-weight: 600;
+}
+
+.workspace-members-page__head-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.workspace-members-page__role-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  background: var(--cp-accent-soft-bg);
+  color: var(--cp-accent-primary);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.workspace-members-page__count {
+  font-size: 0.75rem;
+  color: var(--cp-text-subtle);
+}
+
+.workspace-members-page__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.workspace-members-page__error {
+  margin: 0;
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: rgba(127, 29, 29, 0.18);
+  color: #fecaca;
+  font-size: 0.8125rem;
+}
+
+.workspace-members-page__empty {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  border: 1px dashed var(--cp-border-dashed);
+  background: var(--cp-surface-subtle);
+  color: var(--cp-text-subtle);
+  font-size: 0.8125rem;
+  text-align: center;
+}
+
+.workspace-members-page__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.workspace-members-page__row {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  padding: 0.875rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--cp-border-default);
+  background: var(--cp-surface-raised);
+}
+
+.workspace-members-page__avatar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  background: var(--cp-surface-app);
+  border: 1px solid var(--cp-border-muted);
+  color: var(--cp-text-icon-muted);
+}
+
+.workspace-members-page__meta {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.workspace-members-page__name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.workspace-members-page__name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--cp-text-primary);
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-members-page__badge {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 0.16rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.workspace-members-page__badge--owner {
+  background: color-mix(in srgb, var(--cp-accent-soft-bg) 78%, transparent);
+  border-color: color-mix(in srgb, var(--cp-accent-primary) 30%, transparent);
+  color: var(--cp-accent-primary);
+}
+
+.workspace-members-page__badge--self {
+  background: var(--cp-surface-subtle);
+  border-color: var(--cp-border-default);
+  color: var(--cp-text-subtle);
+}
+
+.workspace-members-page__details {
+  font-size: 0.75rem;
+  color: var(--cp-text-subtle);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-members-page__remove {
+  flex-shrink: 0;
+  padding: 0.45rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid var(--cp-border-default);
+  background: var(--cp-surface-app);
+  color: var(--cp-text-primary);
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.workspace-members-page__remove:hover:not(:disabled) {
+  background: var(--cp-surface-subtle);
+  border-color: var(--cp-border-input-hover);
+}
+
+.workspace-members-page__remove:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.workspace-members-page__form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--cp-border-default);
+  background: var(--cp-surface-raised);
+}
+
+.workspace-members-page__form-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.workspace-members-page__input,
+.workspace-members-page__select {
+  min-height: 2.25rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: 8px;
+  border: 1px solid var(--cp-border-default);
+  background: var(--cp-surface-app);
+  color: var(--cp-text-primary);
+  font: inherit;
+  font-size: 0.8125rem;
+}
+
+.workspace-members-page__input {
+  flex: 1 1 220px;
+}
+
+.workspace-members-page__select {
+  flex: 0 0 auto;
+}
+
+.workspace-members-page__submit {
+  align-self: flex-start;
+  padding: 0.5rem 0.875rem;
+  border-radius: 8px;
+  border: none;
+  background: var(--cp-accent-primary);
+  color: var(--cp-accent-on-primary);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.workspace-members-page__submit:hover:not(:disabled) {
+  background: var(--cp-accent-primary-hover);
+}
+
+.workspace-members-page__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.workspace-members-page--placeholder {
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.5rem;
+}

--- a/apps/web/src/app/features/workspace-members/workspace-members-page.component.html
+++ b/apps/web/src/app/features/workspace-members/workspace-members-page.component.html
@@ -1,0 +1,101 @@
+@if (workspace(); as ws) {
+  <main class="workspace-members-page" aria-label="Workspace">
+    <header class="workspace-members-page__head">
+      <div class="workspace-members-page__head-row">
+        <div class="workspace-members-page__titles">
+          <h1 class="workspace-members-page__title">Workspace</h1>
+          <p class="workspace-members-page__sub">
+            Manage members and roles for <strong>{{ ws.name }}</strong>
+          </p>
+        </div>
+        <div class="workspace-members-page__head-meta">
+          <span class="workspace-members-page__role-pill">Your role: {{ roleLabel() }}</span>
+          <span class="workspace-members-page__count">{{ memberCountLabel() }}</span>
+        </div>
+      </div>
+    </header>
+
+    <section class="workspace-members-page__body">
+      @if (errorMessage(); as err) {
+        <p class="workspace-members-page__error" role="alert">{{ err }}</p>
+      }
+
+      @if (loading()) {
+        <p class="workspace-members-page__empty">Loading workspace members…</p>
+      } @else if (members().length > 0) {
+        <ul class="workspace-members-page__list">
+          @for (member of members(); track member.userId) {
+            <li class="workspace-members-page__row">
+              <div class="workspace-members-page__avatar" aria-hidden="true">
+                <svg lucideUsers [size]="18" strokeWidth="1.75"></svg>
+              </div>
+              <div class="workspace-members-page__meta">
+                <div class="workspace-members-page__name-row">
+                  <strong class="workspace-members-page__name">
+                    {{ member.displayName || member.email || member.userId }}
+                  </strong>
+                  @if (member.role === 'owner') {
+                    <span class="workspace-members-page__badge workspace-members-page__badge--owner">Owner</span>
+                  }
+                  @if (isCurrentUser(member)) {
+                    <span class="workspace-members-page__badge workspace-members-page__badge--self">You</span>
+                  }
+                </div>
+                <span class="workspace-members-page__details">
+                  {{ member.email || 'No email' }} · {{ member.role }}
+                </span>
+              </div>
+              @if (canManageMembers() && canRemoveMember(member)) {
+                <button
+                  type="button"
+                  class="workspace-members-page__remove"
+                  [disabled]="mutationPending()"
+                  (click)="onRemoveMember(member.userId)"
+                >
+                  Remove
+                </button>
+              }
+            </li>
+          }
+        </ul>
+      } @else {
+        <p class="workspace-members-page__empty">No workspace members yet.</p>
+      }
+
+      @if (canManageMembers()) {
+        <form
+          class="workspace-members-page__form"
+          #memberForm="ngForm"
+          (ngSubmit)="onAddMember(memberEmail.value, memberRole.value); memberForm.resetForm({ role: 'viewer' })"
+        >
+          <div class="workspace-members-page__form-fields">
+            <input
+              #memberEmail
+              type="email"
+              name="email"
+              required
+              placeholder="colleague@example.com"
+              class="workspace-members-page__input"
+            />
+            <select #memberRole name="role" class="workspace-members-page__select">
+              <option value="viewer">Viewer</option>
+              <option value="editor">Editor</option>
+              <option value="owner">Owner</option>
+            </select>
+          </div>
+          <button
+            type="submit"
+            class="workspace-members-page__submit"
+            [disabled]="mutationPending() || !memberForm.form.valid"
+          >
+            Add member
+          </button>
+        </form>
+      }
+    </section>
+  </main>
+} @else {
+  <main class="workspace-members-page workspace-members-page--placeholder" aria-label="Workspace">
+    <p class="workspace-members-page__empty">Select a project to view its workspace members.</p>
+  </main>
+}

--- a/apps/web/src/app/features/workspace-members/workspace-members-page.component.spec.ts
+++ b/apps/web/src/app/features/workspace-members/workspace-members-page.component.spec.ts
@@ -1,0 +1,181 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, expect, it, vi } from 'vitest';
+import { resolveAngularExternalResources, setupAngularVitest } from '../../testing/angular-vitest';
+import type { WorkspaceMember } from './models/workspace-member.model';
+import { WorkspaceMembersPageComponent, type WorkspacePageWorkspaceSummary } from './workspace-members-page.component';
+
+setupAngularVitest();
+
+const ownerWorkspace: WorkspacePageWorkspaceSummary = {
+  id: 'workspace-1',
+  name: 'Workspace project',
+  role: 'owner',
+  isPersonal: false,
+  capabilities: { canEdit: true, canManageMembers: true },
+};
+
+const membersFixture: WorkspaceMember[] = [
+  {
+    userId: 'user-1',
+    email: 'owner@example.com',
+    displayName: 'Owner User',
+    role: 'owner',
+    createdAt: '2026-04-08T10:00:00.000Z',
+  },
+  {
+    userId: 'user-2',
+    email: 'editor@example.com',
+    displayName: 'Editor User',
+    role: 'editor',
+    createdAt: '2026-04-08T10:05:00.000Z',
+  },
+];
+
+async function renderPage(
+  overrides: {
+    workspace?: WorkspacePageWorkspaceSummary | null;
+    currentUserId?: string | null;
+    currentUserEmail?: string | null;
+    members?: WorkspaceMember[];
+    loading?: boolean;
+    errorMessage?: string | null;
+    mutationPending?: boolean;
+  } = {},
+) {
+  await resolveAngularExternalResources();
+  await TestBed.configureTestingModule({
+    imports: [WorkspaceMembersPageComponent],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(WorkspaceMembersPageComponent);
+  const component = fixture.componentInstance as unknown as {
+    workspace: () => WorkspacePageWorkspaceSummary | null;
+    currentUserId: () => string | null;
+    currentUserEmail: () => string | null;
+    members: () => WorkspaceMember[];
+    loading: () => boolean;
+    errorMessage: () => string | null;
+    mutationPending: () => boolean;
+  };
+
+  component.workspace = () => ('workspace' in overrides ? (overrides.workspace ?? null) : ownerWorkspace);
+  component.currentUserId = () => overrides.currentUserId ?? null;
+  component.currentUserEmail = () => overrides.currentUserEmail ?? null;
+  component.members = () => overrides.members ?? membersFixture;
+  component.loading = () => overrides.loading ?? false;
+  component.errorMessage = () => overrides.errorMessage ?? null;
+  component.mutationPending = () => overrides.mutationPending ?? false;
+
+  fixture.detectChanges();
+  await fixture.whenStable();
+  fixture.detectChanges();
+
+  return fixture;
+}
+
+describe('WorkspaceMembersPageComponent', () => {
+  it('renders workspace name, role label, and member rows', async () => {
+    const fixture = await renderPage();
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('.workspace-members-page__title')?.textContent).toContain('Workspace');
+    expect(element.querySelector('.workspace-members-page__sub')?.textContent).toContain('Workspace project');
+    expect(element.querySelector('.workspace-members-page__role-pill')?.textContent).toContain('Owner');
+
+    const rows = Array.from(element.querySelectorAll('.workspace-members-page__row'));
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.textContent).toContain('Owner User');
+    expect(rows[1]?.textContent).toContain('Editor User');
+  });
+
+  it('hides remove button for owner self and renders owner/self badges', async () => {
+    const fixture = await renderPage({
+      workspace: ownerWorkspace,
+      currentUserId: 'user-1',
+    });
+    const element = fixture.nativeElement as HTMLElement;
+    const rows = Array.from(element.querySelectorAll('.workspace-members-page__row'));
+
+    expect(rows[0]?.textContent).toContain('Owner User');
+    expect(rows[0]?.querySelector('.workspace-members-page__remove')).toBeNull();
+    expect(rows[0]?.querySelector('.workspace-members-page__badge--owner')?.textContent).toContain('Owner');
+    expect(rows[0]?.querySelector('.workspace-members-page__badge--self')?.textContent).toContain('You');
+    expect(rows[1]?.querySelector('.workspace-members-page__remove')?.textContent).toContain('Remove');
+  });
+
+  it('detects current user by email when userId differs', async () => {
+    const fixture = await renderPage({
+      currentUserId: 'another-id',
+      currentUserEmail: 'owner@example.com',
+    });
+    const element = fixture.nativeElement as HTMLElement;
+    const rows = Array.from(element.querySelectorAll('.workspace-members-page__row'));
+
+    expect(rows[0]?.querySelector('.workspace-members-page__badge--self')?.textContent).toContain('You');
+    expect(rows[0]?.querySelector('.workspace-members-page__remove')).toBeNull();
+  });
+
+  it('emits removeMember when an actionable member row triggers remove', async () => {
+    const fixture = await renderPage();
+    const component = fixture.componentInstance;
+    const emitSpy = vi.fn();
+    const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(true);
+    component.removeMember.subscribe(emitSpy);
+
+    const button = (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLButtonElement>(
+      '.workspace-members-page__remove',
+    )[0];
+    button?.click();
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith('user-1');
+    confirmSpy.mockRestore();
+  });
+
+  it('does not emit removeMember when remove confirmation is cancelled', async () => {
+    const fixture = await renderPage();
+    const component = fixture.componentInstance;
+    const emitSpy = vi.fn();
+    const confirmSpy = vi.spyOn(globalThis, 'confirm').mockReturnValue(false);
+    component.removeMember.subscribe(emitSpy);
+
+    const button = (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLButtonElement>(
+      '.workspace-members-page__remove',
+    )[0];
+    button?.click();
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it('emits addMember with normalized payload when the form is submitted', async () => {
+    const fixture = await renderPage();
+    const component = fixture.componentInstance;
+    const emitSpy = vi.fn();
+    component.addMember.subscribe(emitSpy);
+
+    const element = fixture.nativeElement as HTMLElement;
+    const emailInput = element.querySelector<HTMLInputElement>('.workspace-members-page__input');
+    const roleSelect = element.querySelector<HTMLSelectElement>('.workspace-members-page__select');
+    const form = element.querySelector('form');
+
+    if (!emailInput || !roleSelect || !form) {
+      throw new Error('Form fields not rendered');
+    }
+
+    emailInput.value = '  newcomer@example.com  ';
+    roleSelect.value = 'editor';
+    form.dispatchEvent(new Event('submit'));
+
+    expect(emitSpy).toHaveBeenCalledWith({ email: 'newcomer@example.com', role: 'editor' });
+  });
+
+  it('shows a placeholder when no workspace is bound yet', async () => {
+    const fixture = await renderPage({ workspace: null });
+    const element = fixture.nativeElement as HTMLElement;
+
+    expect(element.querySelector('.workspace-members-page--placeholder')).not.toBeNull();
+    expect(element.textContent).toContain('Select a project');
+  });
+});

--- a/apps/web/src/app/features/workspace-members/workspace-members-page.component.ts
+++ b/apps/web/src/app/features/workspace-members/workspace-members-page.component.ts
@@ -1,0 +1,104 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { LucideUsers } from '@lucide/angular';
+
+import type { WorkspaceRoleDto } from '../../shared/http/api.types';
+import type { WorkspaceMember } from './models/workspace-member.model';
+
+export interface WorkspacePageWorkspaceSummary {
+  id: string;
+  name: string;
+  role: WorkspaceRoleDto;
+  isPersonal?: boolean;
+  capabilities: {
+    canEdit: boolean;
+    canManageMembers: boolean;
+  };
+}
+
+@Component({
+  selector: 'app-workspace-members-page',
+  standalone: true,
+  imports: [FormsModule, LucideUsers],
+  templateUrl: './workspace-members-page.component.html',
+  styleUrls: ['./workspace-members-page.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class WorkspaceMembersPageComponent {
+  readonly workspace = input<WorkspacePageWorkspaceSummary | null>(null);
+  readonly currentUserId = input<string | null>(null);
+  readonly currentUserEmail = input<string | null>(null);
+  readonly members = input<WorkspaceMember[]>([]);
+  readonly loading = input(false);
+  readonly errorMessage = input<string | null>(null);
+  readonly mutationPending = input(false);
+
+  readonly addMember = output<{ email: string; role: WorkspaceRoleDto }>();
+  readonly removeMember = output<string>();
+
+  protected readonly canManageMembers = computed(() => this.workspace()?.capabilities.canManageMembers ?? false);
+
+  protected readonly roleLabel = computed(() => {
+    switch (this.workspace()?.role) {
+      case 'owner':
+        return 'Owner';
+      case 'editor':
+        return 'Editor';
+      case 'viewer':
+        return 'Viewer';
+      default:
+        return '—';
+    }
+  });
+
+  protected readonly memberCountLabel = computed(() => {
+    const count = this.members().length;
+    return count === 1 ? '1 member' : `${count} members`;
+  });
+
+  private normalizeEmail(value: string | null | undefined): string {
+    return (value ?? '').trim().toLowerCase();
+  }
+
+  protected isCurrentUser(member: WorkspaceMember): boolean {
+    const currentUserId = this.currentUserId();
+    if (currentUserId && currentUserId === member.userId) {
+      return true;
+    }
+
+    const currentUserEmail = this.normalizeEmail(this.currentUserEmail());
+    const memberEmail = this.normalizeEmail(member.email);
+    return !!currentUserEmail && currentUserEmail === memberEmail;
+  }
+
+  protected canRemoveMember(member: WorkspaceMember): boolean {
+    if (!this.canManageMembers() || this.mutationPending()) {
+      return false;
+    }
+
+    const isOwnerSelfRemoval = this.isCurrentUser(member) && member.role === 'owner';
+
+    return !isOwnerSelfRemoval;
+  }
+
+  protected onAddMember(email: string, role: string): void {
+    if (!this.canManageMembers() || this.mutationPending()) return;
+
+    const normalizedEmail = email.trim();
+    if (!normalizedEmail) return;
+
+    const nextRole: WorkspaceRoleDto = role === 'owner' || role === 'editor' ? role : 'viewer';
+    this.addMember.emit({ email: normalizedEmail, role: nextRole });
+  }
+
+  protected onRemoveMember(memberUserId: string): void {
+    const member = this.members().find((item) => item.userId === memberUserId);
+    if (!member || !this.canRemoveMember(member)) return;
+
+    const memberLabel = member.displayName || member.email || member.userId;
+    const confirmed = globalThis.confirm(`Remove ${memberLabel} from this workspace?`);
+    if (!confirmed) return;
+
+    this.removeMember.emit(memberUserId);
+  }
+}

--- a/apps/web/src/app/features/workspace-shell/models/workspace-shell.model.ts
+++ b/apps/web/src/app/features/workspace-shell/models/workspace-shell.model.ts
@@ -1,5 +1,5 @@
 /** Secciones principales del workspace (barra lateral + área central). */
-export type WorkspaceNavId = 'dashboard' | 'endpoints' | 'logs' | 'history';
+export type WorkspaceNavId = 'dashboard' | 'endpoints' | 'logs' | 'history' | 'workspace';
 
 export interface SidebarProjectRow {
   id: string;

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.html
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.html
@@ -2,6 +2,9 @@
   [projects]="sidebarProjects()"
   [selectedProjectId]="selectedProjectId()"
   [activeNav]="activeNav()"
+  [showSignOut]="authSnapshot().state === 'authenticated' || protectedApiAccessState() === 'unauthorized'"
+  [userDisplayName]="authSnapshot().displayName"
+  [userAvatarUrl]="authSnapshot().avatarUrl"
   [loading]="projectsLoading()"
   [errorMessage]="projectsError()"
   [pagination]="sidebarProjectPagination()"
@@ -10,6 +13,7 @@
   (createProjectRequested)="openCreateProjectModal()"
   (retryRequested)="retryLoadProjects()"
   (loadMoreRequested)="loadMoreProjects()"
+  (signOutRequested)="signOut()"
 />
 
 @if (createEndpointFlowOpen()) {
@@ -166,6 +170,20 @@
       (loadMore)="loadMoreEndpoints()"
     />
   </main>
+} @else if (activeNav() === 'workspace') {
+  <main class="workspace__main" aria-label="Workspace members">
+    <app-workspace-members-page
+      [workspace]="activeWorkspaceSummary()"
+      [currentUserId]="authSnapshot().userId"
+      [currentUserEmail]="authSnapshot().email"
+      [members]="workspaceMembers()"
+      [loading]="workspaceMembersLoading()"
+      [errorMessage]="workspaceMembersError()"
+      [mutationPending]="workspaceMemberMutationPending()"
+      (addMember)="addWorkspaceMember($event)"
+      (removeMember)="removeWorkspaceMember($event)"
+    />
+  </main>
 }
 
 @if (contractImportReview(); as review) {
@@ -220,10 +238,6 @@
     <app-main-dashboard-utility-sidebar
       [project]="project"
       [canMutate]="canMutateActiveWorkspace()"
-      [workspaceMembers]="workspaceMembers()"
-      [workspaceMembersLoading]="workspaceMembersLoading()"
-      [workspaceMembersError]="workspaceMembersError()"
-      [workspaceMemberMutationPending]="workspaceMemberMutationPending()"
       (createEndpoint)="createEndpoint()"
       (createManualEndpoint)="createEndpoint('manual')"
       (createSnapshot)="createSnapshot()"
@@ -231,8 +245,6 @@
       (exportConfig)="exportConfig()"
       (importEndpoints)="importEndpoints()"
       (editGlobalConfig)="editGlobalConfig()"
-      (addWorkspaceMember)="addWorkspaceMember($event)"
-      (removeWorkspaceMember)="removeWorkspaceMember($event)"
     />
   }
 } @else if (activeNav() === 'endpoints' && !createEndpointFlowOpen() && hasProjects()) {

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.spec.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.spec.ts
@@ -40,7 +40,7 @@ type WorkspaceShellTestApi = {
   selectedProjectId: WritableSignalLike<string>;
   selectedEndpointId: WritableSignalLike<string | null>;
   selectedLog: WritableSignalLike<ApiLogEntry | null>;
-  activeNav: WritableSignalLike<'dashboard' | 'logs' | 'endpoints'>;
+  activeNav: WritableSignalLike<'dashboard' | 'logs' | 'endpoints' | 'history' | 'workspace'>;
   globalConfig: WritableSignalLike<GlobalConfig>;
   globalConfigDrawerOpen: WritableSignalLike<boolean>;
   globalConfigError: () => string | null;
@@ -62,6 +62,14 @@ type WorkspaceShellTestApi = {
   retryLoadProjects(): void;
   loadMoreProjects(): void;
   selectProject(id: string): void;
+  selectNav(id: 'dashboard' | 'logs' | 'endpoints' | 'history' | 'workspace'): void;
+  activeWorkspaceSummary: () => {
+    id: string;
+    name: string;
+    role: 'owner' | 'editor' | 'viewer';
+    isPersonal?: boolean;
+    capabilities: { canEdit: boolean; canManageMembers: boolean };
+  } | null;
   editGlobalConfig(): void;
   openEditProjectModal(): void;
   onEditProjectModalSave(payload: EditProjectModalPayload): void;
@@ -377,6 +385,17 @@ describe('WorkspaceShellComponent', () => {
     expect(component.selectedProjectId()).toBe('');
   });
 
+  it('delegates sign out requests to the frontend auth session service', async () => {
+    projectsRepository.listProjects.mockResolvedValue(pagedProjectsResult([projectFixture]));
+
+    const component = createComponent() as WorkspaceShellTestApi & { signOut(): void };
+    await flushAsyncWork();
+
+    component.signOut();
+
+    expect(authSession.signOut).toHaveBeenCalledTimes(1);
+  });
+
   it('blocks viewer-only mutations from the current workspace slice', async () => {
     projectsRepository.listProjects.mockResolvedValue(
       pagedProjectsResult([
@@ -457,6 +476,37 @@ describe('WorkspaceShellComponent', () => {
 
     expect(workspaceMembersRepository.addMember).toHaveBeenCalledTimes(1);
     expect(workspaceMembersRepository.removeMember).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads workspace members and exposes a workspace summary when the user navigates to the workspace section', async () => {
+    projectsRepository.listProjects.mockResolvedValue(pagedProjectsResult([projectFixture]));
+    projectsRepository.getProject.mockResolvedValue(projectFixture);
+    workspaceMembersRepository.listMembers.mockResolvedValue([
+      {
+        userId: 'user-1',
+        email: 'owner@example.com',
+        displayName: 'Owner User',
+        role: 'owner',
+        createdAt: '2026-04-08T10:00:00.000Z',
+      },
+    ]);
+
+    const component = createComponent();
+    await flushAsyncWork();
+    workspaceMembersRepository.listMembers.mockClear();
+
+    component.selectNav('workspace');
+    await flushAsyncWork();
+
+    expect(component.activeNav()).toBe('workspace');
+    expect(workspaceMembersRepository.listMembers).toHaveBeenCalledWith('workspace-1');
+    expect(component.activeWorkspaceSummary()).toEqual({
+      id: 'workspace-1',
+      name: 'Workspace project',
+      role: 'owner',
+      isPersonal: undefined,
+      capabilities: { canEdit: true, canManageMembers: true },
+    });
   });
 
   it('hydrates the initially selected project with the real dashboard summary after loading the sidebar list', async () => {
@@ -775,7 +825,7 @@ describe('WorkspaceShellComponent', () => {
     expect(component.createProjectModalLoading()).toBe(false);
   });
 
-  it('allows continuing manually after partial success without clearing the created project', async () => {
+  it('routes partial project success into the shared manual endpoint flow', async () => {
     projectsRepository.listProjects.mockResolvedValue(pagedProjectsResult([projectFixture]));
 
     const component = createComponent();

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.ts
@@ -1,12 +1,8 @@
 import { TitleCasePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { FrontendAuthSessionService } from '../../shared/auth/frontend-auth-session.service';
 import { ApiError } from '../../shared/http/api-error.mapper';
 import type { OpenApiContractAnalyzeDto } from '../../shared/http/api.types';
-import { FrontendAuthSessionService } from '../../shared/auth/frontend-auth-session.service';
-import { AuditHistoryComponent } from '../audit-history/audit-history.component';
-import { ProjectContractsRepository } from './data-access/project-contracts.repository';
-import { ProjectSnapshotsRepository } from '../project-snapshots/data-access/project-snapshots.repository';
-import type { ProjectSnapshot } from '../project-snapshots/models/project-snapshot.model';
 import type { EndpointPreview } from '../../shared/models/endpoint-preview.model';
 import { ConfirmDialogComponent } from '../../shared/ui/confirm-dialog/confirm-dialog.component';
 import { CreateProjectModalComponent } from '../../shared/ui/create-project-modal/create-project-modal.component';
@@ -17,8 +13,13 @@ import type {
   ProjectModalInitialValues,
   ProjectModalMode,
 } from '../../shared/ui/create-project-modal/create-project-modal.model';
+import { AuditHistoryComponent } from '../audit-history/audit-history.component';
 import { CreateEndpointPageComponent } from '../endpoints/components/create-endpoint-page/create-endpoint-page.component';
 import { EndpointDetailPanelComponent } from '../endpoints/components/endpoint-detail-panel/endpoint-detail-panel.component';
+import type {
+  EndpointsListMethodFilter,
+  EndpointsListSortOption,
+} from '../endpoints/components/endpoints-list/endpoints-list.constants';
 import { EndpointsRepository } from '../endpoints/data-access/endpoints.repository';
 import { EndpointsPageComponent } from '../endpoints/endpoints-page.component';
 import type { EndpointFlowMode } from '../endpoints/models/endpoint-draft.model';
@@ -34,12 +35,15 @@ import { MainDashboardSidebarComponent } from '../main-dashboard/components/main
 import { MainDashboardUtilitySidebarComponent } from '../main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component';
 import { ProjectsRepository } from '../main-dashboard/data-access/projects.repository';
 import type { DashboardProject } from '../main-dashboard/models/dashboard-project.model';
+import { ProjectSnapshotsRepository } from '../project-snapshots/data-access/project-snapshots.repository';
+import type { ProjectSnapshot } from '../project-snapshots/models/project-snapshot.model';
 import { WorkspaceMembersRepository } from '../workspace-members/data-access/workspace-members.repository';
 import type { WorkspaceMember } from '../workspace-members/models/workspace-member.model';
-import type {
-  EndpointsListMethodFilter,
-  EndpointsListSortOption,
-} from '../endpoints/components/endpoints-list/endpoints-list.constants';
+import {
+  WorkspaceMembersPageComponent,
+  type WorkspacePageWorkspaceSummary,
+} from '../workspace-members/workspace-members-page.component';
+import { ProjectContractsRepository } from './data-access/project-contracts.repository';
 import type {
   CreateProjectAiFlowState,
   EndpointListState,
@@ -73,6 +77,7 @@ interface ContractImportReviewState {
     GlobalConfigDrawerComponent,
     CreateProjectModalComponent,
     ConfirmDialogComponent,
+    WorkspaceMembersPageComponent,
   ],
   templateUrl: './workspace-shell.component.html',
   styleUrls: ['./workspace-shell.component.css'],
@@ -167,6 +172,18 @@ export class WorkspaceShellComponent {
   protected readonly workspaceMembersLoading = signal(false);
   protected readonly workspaceMembersError = signal<string | null>(null);
   protected readonly workspaceMemberMutationPending = signal(false);
+
+  protected readonly activeWorkspaceSummary = computed((): WorkspacePageWorkspaceSummary | null => {
+    const project = this.activeProject();
+    if (!project) return null;
+    return {
+      id: project.workspace.id,
+      name: project.name,
+      role: project.workspace.role,
+      isPersonal: project.workspace.isPersonal,
+      capabilities: project.workspace.capabilities,
+    };
+  });
 
   protected readonly endpointList = signal<EndpointPreview[]>([]);
   protected readonly endpointListLoading = signal(false);
@@ -410,6 +427,12 @@ export class WorkspaceShellComponent {
         void this.loadSnapshotHistory(projectId);
       }
     }
+    if (id === 'workspace') {
+      const workspaceId = this.activeProject()?.workspace.id;
+      if (workspaceId) {
+        void this.reloadWorkspaceMembers(workspaceId);
+      }
+    }
     if (id !== 'endpoints') {
       this.selectedEndpointId.set(null);
       this.createEndpointFlowOpen.set(false);
@@ -457,8 +480,8 @@ export class WorkspaceShellComponent {
 
   protected closeCreateEndpointWizard(restorePreviousNav = false): void {
     this.createEndpointFlowOpen.set(false);
-    this.endpointWizardMode.set('ai');
     this.endpointWizardInitial.set(null);
+    this.endpointWizardMode.set('ai');
     if (restorePreviousNav) {
       const prev = this.navBeforeCreateFlow();
       if (prev !== null) this.activeNav.set(prev);

--- a/apps/web/src/app/shared/auth/auth.guard.spec.ts
+++ b/apps/web/src/app/shared/auth/auth.guard.spec.ts
@@ -1,18 +1,62 @@
-import { Injector, runInInjectionContext } from '@angular/core';
+import { Injector, signal, runInInjectionContext } from '@angular/core';
 import { Router } from '@angular/router';
 import { describe, expect, it, vi } from 'vitest';
 import { authGuard } from './auth.guard';
 import { FrontendAuthSessionService } from './frontend-auth-session.service';
 
 describe('authGuard', () => {
-  it('redirects unauthenticated users to /auth', async () => {
+  function createAuthSession(options?: {
+    canAccessProtectedRoutes?: boolean;
+    snapshotState?: 'authenticated' | 'unauthenticated' | 'misconfigured' | 'error' | 'loading';
+    accessState?: 'ready' | 'unauthenticated' | 'unauthorized';
+  }) {
+    return {
+      snapshot: signal({
+        state: options?.snapshotState ?? 'authenticated',
+        userId: null,
+        displayName: null,
+        avatarUrl: null,
+        email: null,
+        emailVerified: false,
+        headers: null,
+        reason: null,
+      }),
+      accessState: signal(options?.accessState ?? 'ready'),
+      bootstrap: vi.fn(async () => undefined),
+      openSignIn: vi.fn(async () => undefined),
+      canAccessProtectedRoutes: vi.fn(() => options?.canAccessProtectedRoutes ?? false),
+    };
+  }
+
+  it('allows authenticated users through', async () => {
+    const authSession = createAuthSession({
+      canAccessProtectedRoutes: true,
+      snapshotState: 'authenticated',
+    });
+
+    const injector = Injector.create({
+      providers: [
+        { provide: Router, useValue: { createUrlTree: vi.fn() } },
+        { provide: FrontendAuthSessionService, useValue: authSession },
+      ],
+    });
+
+    const result = await runInInjectionContext(injector, () => authGuard({} as never, {} as never));
+
+    expect(authSession.bootstrap).toHaveBeenCalledOnce();
+    expect(authSession.openSignIn).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('opens Clerk sign-in directly when unauthenticated', async () => {
     const router = {
       createUrlTree: vi.fn((segments: string[]) => ({ segments })),
     };
-    const authSession = {
-      bootstrap: vi.fn(async () => undefined),
-      canAccessProtectedRoutes: vi.fn(() => false),
-    };
+    const authSession = createAuthSession({
+      canAccessProtectedRoutes: false,
+      snapshotState: 'unauthenticated',
+      accessState: 'ready',
+    });
 
     const injector = Injector.create({
       providers: [
@@ -24,25 +68,56 @@ describe('authGuard', () => {
     const result = await runInInjectionContext(injector, () => authGuard({} as never, {} as never));
 
     expect(authSession.bootstrap).toHaveBeenCalledOnce();
-    expect(router.createUrlTree).toHaveBeenCalledWith(['/auth']);
-    expect(result).toEqual({ segments: ['/auth'] });
+    expect(authSession.openSignIn).toHaveBeenCalledOnce();
+    expect(router.createUrlTree).not.toHaveBeenCalled();
+    expect(result).toBe(false);
   });
 
-  it('allows authenticated users through', async () => {
-    const authSession = {
-      bootstrap: vi.fn(async () => undefined),
-      canAccessProtectedRoutes: vi.fn(() => true),
+  it('keeps the /auth fallback for misconfigured or failed auth states', async () => {
+    const router = {
+      createUrlTree: vi.fn((segments: string[]) => ({ segments })),
     };
+    const authSession = createAuthSession({
+      canAccessProtectedRoutes: false,
+      snapshotState: 'misconfigured',
+    });
 
     const injector = Injector.create({
       providers: [
-        { provide: Router, useValue: { createUrlTree: vi.fn() } },
+        { provide: Router, useValue: router },
         { provide: FrontendAuthSessionService, useValue: authSession },
       ],
     });
 
     const result = await runInInjectionContext(injector, () => authGuard({} as never, {} as never));
 
-    expect(result).toBe(true);
+    expect(authSession.bootstrap).toHaveBeenCalledOnce();
+    expect(authSession.openSignIn).not.toHaveBeenCalled();
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/auth']);
+    expect(result).toEqual({ segments: ['/auth'] });
+  });
+
+  it('keeps the /auth fallback when access is unauthorized', async () => {
+    const router = {
+      createUrlTree: vi.fn((segments: string[]) => ({ segments })),
+    };
+    const authSession = createAuthSession({
+      canAccessProtectedRoutes: false,
+      snapshotState: 'unauthenticated',
+      accessState: 'unauthorized',
+    });
+
+    const injector = Injector.create({
+      providers: [
+        { provide: Router, useValue: router },
+        { provide: FrontendAuthSessionService, useValue: authSession },
+      ],
+    });
+
+    const result = await runInInjectionContext(injector, () => authGuard({} as never, {} as never));
+
+    expect(authSession.openSignIn).not.toHaveBeenCalled();
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/auth']);
+    expect(result).toEqual({ segments: ['/auth'] });
   });
 });

--- a/apps/web/src/app/shared/auth/auth.guard.ts
+++ b/apps/web/src/app/shared/auth/auth.guard.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import type { CanActivateFn} from '@angular/router';
+import type { CanActivateFn } from '@angular/router';
 import { Router } from '@angular/router';
 import { FrontendAuthSessionService } from './frontend-auth-session.service';
 
@@ -9,5 +9,14 @@ export const authGuard: CanActivateFn = async () => {
 
   await authSession.bootstrap();
 
-  return authSession.canAccessProtectedRoutes() ? true : router.createUrlTree(['/auth']);
+  if (authSession.canAccessProtectedRoutes()) {
+    return true;
+  }
+
+  if (authSession.snapshot().state === 'unauthenticated' && authSession.accessState() !== 'unauthorized') {
+    await authSession.openSignIn();
+    return false;
+  }
+
+  return router.createUrlTree(['/auth']);
 };

--- a/apps/web/src/app/shared/auth/clerk-frontend-auth.adapter.spec.ts
+++ b/apps/web/src/app/shared/auth/clerk-frontend-auth.adapter.spec.ts
@@ -53,6 +53,7 @@ describe('ClerkFrontendAuthAdapter', () => {
       user: {
         id: 'user_clerk_123',
         fullName: 'Owner User',
+        imageUrl: 'https://cdn.clerk.dev/avatar.png',
         primaryEmailAddress: {
           emailAddress: 'owner@example.com',
           verification: { status: 'verified' },
@@ -80,6 +81,7 @@ describe('ClerkFrontendAuthAdapter', () => {
       userId: 'user_clerk_123',
       email: 'owner@example.com',
       displayName: 'Owner User',
+      avatarUrl: 'https://cdn.clerk.dev/avatar.png',
       headers: {
         authStatus: 'signed-in',
         userId: 'user_clerk_123',

--- a/apps/web/src/app/shared/auth/clerk-frontend-auth.adapter.ts
+++ b/apps/web/src/app/shared/auth/clerk-frontend-auth.adapter.ts
@@ -20,6 +20,7 @@ export class ClerkFrontendAuthAdapter implements FrontendAuthAdapter {
         state: 'misconfigured',
         userId: null,
         displayName: null,
+        avatarUrl: null,
         email: null,
         emailVerified: false,
         headers: null,
@@ -44,6 +45,7 @@ export class ClerkFrontendAuthAdapter implements FrontendAuthAdapter {
         state: 'error',
         userId: null,
         displayName: null,
+        avatarUrl: null,
         email: null,
         emailVerified: false,
         headers: null,
@@ -89,12 +91,14 @@ export class ClerkFrontendAuthAdapter implements FrontendAuthAdapter {
     const email = primaryEmail?.emailAddress ?? null;
     const emailVerified = primaryEmail?.verification.status === 'verified';
     const displayName = user?.fullName ?? email ?? user?.id ?? null;
+    const avatarUrl = user?.imageUrl ?? null;
 
     if (!clerk.isSignedIn || !user) {
       return {
         state: 'unauthenticated',
         userId: null,
         displayName: null,
+        avatarUrl: null,
         email: null,
         emailVerified: false,
         headers: null,
@@ -106,6 +110,7 @@ export class ClerkFrontendAuthAdapter implements FrontendAuthAdapter {
       state: 'authenticated',
       userId: user.id,
       displayName,
+      avatarUrl,
       email,
       emailVerified,
       headers: {

--- a/apps/web/src/app/shared/auth/models/frontend-auth.model.ts
+++ b/apps/web/src/app/shared/auth/models/frontend-auth.model.ts
@@ -12,6 +12,7 @@ export interface FrontendAuthSnapshot {
   state: FrontendAuthState;
   userId: string | null;
   displayName: string | null;
+  avatarUrl: string | null;
   email: string | null;
   emailVerified: boolean;
   headers: FrontendSessionHeaders | null;
@@ -24,6 +25,7 @@ export const loadingFrontendAuthSnapshot: FrontendAuthSnapshot = {
   state: 'loading',
   userId: null,
   displayName: null,
+  avatarUrl: null,
   email: null,
   emailVerified: false,
   headers: null,

--- a/openspec/changes/sidebar-user-mini-profile/design.md
+++ b/openspec/changes/sidebar-user-mini-profile/design.md
@@ -1,0 +1,46 @@
+# Design: Sidebar User Mini Profile
+
+## Technical Approach
+
+The sidebar identity section reads authenticated data already available in the frontend session snapshot. We extend the snapshot contract with `avatarUrl?: string | null`, map it in the Clerk adapter, and pass `displayName` + `avatarUrl` from workspace shell into the sidebar component. Rendering stays local to the sidebar with safe guards and a fallback avatar token.
+
+## Architecture Decisions
+
+| Decision           | Options                                   | Choice                                      | Rationale                                                              |
+| ------------------ | ----------------------------------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
+| Avatar data source | New API endpoint; Clerk session snapshot  | Clerk session snapshot                      | Zero backend changes and immediate consistency with current auth state |
+| Fallback strategy  | Generic icon; initials                    | Initials from display name                  | Keeps personalized identity signal when no image is available          |
+| Sidebar ownership  | Compute in shell only; compute in sidebar | Pass raw props, compute fallback in sidebar | Keeps template bindings clean and presentation logic colocated         |
+
+## Data Flow
+
+```mermaid
+flowchart TD
+  clerkSession[ClerkSession] --> authAdapter[ClerkFrontendAuthAdapter]
+  authAdapter --> authSnapshot[FrontendAuthSnapshot]
+  authSnapshot --> workspaceShell[WorkspaceShellComponent]
+  workspaceShell --> sidebar[MainDashboardSidebarComponent]
+  sidebar --> userCard[SidebarUserIdentityCard]
+```
+
+## File Changes
+
+| File                                                                                                                  | Action | Description                                                             |
+| --------------------------------------------------------------------------------------------------------------------- | ------ | ----------------------------------------------------------------------- |
+| `apps/web/src/app/shared/auth/models/frontend-auth.model.ts`                                                          | Modify | Add optional `avatarUrl` to `FrontendAuthSnapshot` and loading constant |
+| `apps/web/src/app/shared/auth/clerk-frontend-auth.adapter.ts`                                                         | Modify | Map Clerk `imageUrl` into snapshot for authenticated users              |
+| `apps/web/src/app/shared/auth/clerk-frontend-auth.adapter.spec.ts`                                                    | Modify | Assert avatar mapping in signed-in snapshot                             |
+| `apps/web/src/app/shared/auth/auth.guard.spec.ts`                                                                     | Modify | Update snapshot test fixture shape                                      |
+| `apps/web/src/app/features/workspace-shell/workspace-shell.component.html`                                            | Modify | Provide user display name and avatar inputs to sidebar                  |
+| `apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.ts`      | Modify | Add user inputs and fallback initials computed signal                   |
+| `apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.html`    | Modify | Insert mini user section between active card and sign-out               |
+| `apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.css`     | Modify | Add compact styles for avatar/name row                                  |
+| `apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.spec.ts` | Modify | Cover rendering with avatar and fallback initials                       |
+
+## Testing Strategy
+
+| Layer      | What to Test                                      | Approach                                   |
+| ---------- | ------------------------------------------------- | ------------------------------------------ |
+| Unit       | Auth snapshot includes `avatarUrl`                | `clerk-frontend-auth.adapter.spec.ts`      |
+| Unit       | Sidebar renders name/avatar and fallback initials | `main-dashboard-sidebar.component.spec.ts` |
+| Regression | Sign-out and nav behavior unchanged               | Existing sidebar specs remain green        |

--- a/openspec/changes/sidebar-user-mini-profile/proposal.md
+++ b/openspec/changes/sidebar-user-mini-profile/proposal.md
@@ -1,0 +1,66 @@
+# Proposal: Sidebar User Mini Profile
+
+## Intent
+
+Add a compact identity block in the workspace sidebar so authenticated users can quickly confirm who is signed in without leaving the current project context.
+
+## Scope
+
+### In Scope
+
+- Add a mini section between the active project card and the `Sign out` action.
+- Show the authenticated user name and Clerk avatar image.
+- Extend frontend auth snapshot mapping with optional avatar URL.
+- Add/adjust tests for auth mapping and sidebar rendering fallbacks.
+
+### Out of Scope
+
+- Editing user profile data from the sidebar.
+- Fetching workspace role for this section.
+- Backend API contract changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `sidebar-user-identity`: Render authenticated user identity (avatar + name) in the main workspace sidebar.
+
+### Modified Capabilities
+
+- None.
+
+## Approach
+
+Reuse existing auth session flow (`FrontendAuthSessionService`) by extending `FrontendAuthSnapshot` with an optional `avatarUrl` from Clerk. Pass auth identity fields from `WorkspaceShellComponent` into `MainDashboardSidebarComponent`, where the new mini profile section renders with image-first UI and initials fallback.
+
+## Affected Areas
+
+| Area                                                                           | Impact   | Description                                                          |
+| ------------------------------------------------------------------------------ | -------- | -------------------------------------------------------------------- |
+| `apps/web/src/app/shared/auth/*`                                               | Modified | Include `avatarUrl` in auth snapshot model and Clerk adapter mapping |
+| `apps/web/src/app/features/workspace-shell/*`                                  | Modified | Pass authenticated identity into sidebar inputs                      |
+| `apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/*` | Modified | Add mini profile UI, styling, and render guards                      |
+| `openspec/changes/sidebar-user-mini-profile/*`                                 | New      | Proposal/design/tasks/spec delta                                     |
+
+## Risks
+
+| Risk                                | Likelihood | Mitigation                             |
+| ----------------------------------- | ---------- | -------------------------------------- |
+| Missing avatar for some Clerk users | Med        | Render deterministic initials fallback |
+| Sidebar clutter on small heights    | Low        | Keep section compact and token-aligned |
+
+## Rollback Plan
+
+Revert sidebar identity inputs/markup/styles and remove `avatarUrl` from snapshot mapping. No persistence or backend migration is needed.
+
+## Dependencies
+
+- Existing Clerk session object exposing `imageUrl`.
+- Existing workspace-shell to sidebar binding path.
+
+## Success Criteria
+
+- [ ] Sidebar shows avatar + signed-in user name between active project card and `Sign out`.
+- [ ] Sidebar uses fallback initials when avatar URL is missing or broken.
+- [ ] Existing sign-out behavior remains unchanged.
+- [ ] Auth adapter and sidebar tests pass with the new identity block.

--- a/openspec/changes/sidebar-user-mini-profile/specs/sidebar-user-identity/spec.md
+++ b/openspec/changes/sidebar-user-mini-profile/specs/sidebar-user-identity/spec.md
@@ -1,0 +1,43 @@
+# sidebar-user-identity Specification
+
+## Purpose
+
+Define how authenticated user identity is shown in the main workspace sidebar.
+
+## Requirements
+
+### Requirement: Sidebar User Identity Placement
+
+The system MUST render a compact user identity section between the active project card and the sidebar sign-out action.
+
+#### Scenario: Identity section appears in the expected layout position
+
+- GIVEN the workspace sidebar renders the active project and sign-out controls
+- WHEN an authenticated user identity is available
+- THEN the sidebar SHALL place the user identity section after the active project card and before the sign-out action
+
+### Requirement: Authenticated Identity Content
+
+The user identity section MUST display the signed-in user name and SHOULD display avatar imagery when available from the frontend auth snapshot.
+
+#### Scenario: Avatar URL is present
+
+- GIVEN the auth snapshot state is authenticated with `displayName` and `avatarUrl`
+- WHEN the sidebar renders
+- THEN the section SHALL show the display name and avatar image
+
+#### Scenario: Avatar URL is missing
+
+- GIVEN the auth snapshot state is authenticated with a display name but no avatar URL
+- WHEN the sidebar renders
+- THEN the section SHALL show the display name and SHALL render a deterministic initials fallback avatar
+
+### Requirement: Backward-Compatible Sign-out Behavior
+
+The new identity section MUST NOT change sign-out availability or event behavior.
+
+#### Scenario: Sign-out action still emits existing event
+
+- GIVEN the sidebar renders with sign-out enabled
+- WHEN the user activates sign-out
+- THEN the component SHALL emit the existing `signOutRequested` event exactly as before

--- a/openspec/changes/sidebar-user-mini-profile/tasks.md
+++ b/openspec/changes/sidebar-user-mini-profile/tasks.md
@@ -1,0 +1,17 @@
+# Tasks: Sidebar User Mini Profile
+
+## Phase 1: SDD and auth contract
+
+- [x] 1.1 Create change artifacts (`proposal.md`, `design.md`, `tasks.md`) and delta spec for sidebar identity behavior.
+- [x] 1.2 RED/GREEN: extend `apps/web/src/app/shared/auth/models/frontend-auth.model.ts` and `apps/web/src/app/shared/auth/clerk-frontend-auth.adapter.ts` to include optional `avatarUrl`; update adapter/auth fixtures.
+
+## Phase 2: Sidebar user section
+
+- [x] 2.1 RED: extend `apps/web/src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.spec.ts` to cover user section with avatar and initials fallback.
+- [x] 2.2 GREEN: modify sidebar component TS/HTML/CSS to render compact user identity section between active project card and sign out.
+- [x] 2.3 GREEN: update `apps/web/src/app/features/workspace-shell/workspace-shell.component.html` bindings to pass authenticated display name/avatar into the sidebar.
+
+## Phase 3: Verify
+
+- [x] 3.1 VERIFY: run targeted web tests for `shared/auth` and `main-dashboard-sidebar`.
+- [x] 3.2 VERIFY: run lint diagnostics for touched files and resolve introduced issues.


### PR DESCRIPTION
Closes #68

## Summary
- Muestra identidad de usuario autenticado en sidebar (avatar de Clerk + fallback por iniciales).
- Introduce sección dedicada de workspace members y mueve ahí la gestión de miembros.
- Ajusta snapshot/auth bindings en shell para exponer datos de identidad al layout.

## Test plan
- [x] `pnpm --dir apps/web test -- src/app/features/main-dashboard/components/main-dashboard-sidebar/main-dashboard-sidebar.component.spec.ts`
- [x] `pnpm --dir apps/web test -- src/app/features/main-dashboard/components/main-dashboard-utility-sidebar/main-dashboard-utility-sidebar.component.spec.ts src/app/features/workspace-members/workspace-members-page.component.spec.ts`
- [x] `pnpm --dir apps/web test -- src/app/features/workspace-shell/workspace-shell.component.spec.ts src/app/shared/auth/clerk-frontend-auth.adapter.spec.ts src/app/shared/auth/auth.guard.spec.ts`


Made with [Cursor](https://cursor.com)