### PR TITLE
feat(audit): redesign timeline with grouped filters and paging

### DIFF
--- a/apps/web/src/app/features/audit-history/audit-history.component.css
+++ b/apps/web/src/app/features/audit-history/audit-history.component.css
@@ -1,52 +1,418 @@
+:host {
+  display: contents;
+}
+
 .audit-history {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--cp-border-muted);
+  font-family: Inter, system-ui, sans-serif;
+  background: var(--cp-surface-app);
+  color: var(--cp-text-primary);
+}
+
+.audit-history__head {
+  flex-shrink: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.1rem 1.5rem 0.9rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.audit-history__title {
+  margin: 0 0 0.2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.audit-history__title-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: rgba(34, 197, 94, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.15);
+}
+
+.audit-history__sub {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #6f7680;
+}
+
+.audit-history__count {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.34rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #151a20;
+  color: #f2f6fb;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.audit-history__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.8rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.audit-history__filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  width: min(100%, 760px);
+}
+
+.audit-history__filter {
+  padding: 0.22rem 0.58rem;
+  border-radius: 0.42rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.015);
+  color: #707782;
+  font: inherit;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.audit-history__filter:hover {
+  color: #b8c0cb;
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.audit-history__filter--active {
+  background: #1c2127;
+  border-color: #39404a;
+  color: #ffffff;
+}
+
+.audit-history__groups {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 1.5rem;
+  width: min(100%, 760px);
 }
 
-.audit-history__title,
-.audit-history__sub,
-.audit-history__status,
-.audit-history__summary {
-  margin: 0;
+.audit-history__group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.45rem;
+  padding-bottom: 0.35rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
 }
 
-.audit-history__status--error {
-  color: #b91c1c;
+.audit-history__group-label,
+.audit-history__group-count {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #5e6671;
 }
 
 .audit-history__list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  list-style: none;
   margin: 0;
   padding: 0;
-  list-style: none;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.72rem;
+}
+
+.audit-history__list::before {
+  content: '';
+  position: absolute;
+  left: 0.45rem;
+  top: 0.2rem;
+  bottom: 0.2rem;
+  width: 1px;
+  background: linear-gradient(180deg, rgba(91, 104, 120, 0.35) 0%, rgba(91, 104, 120, 0.1) 100%);
+}
+
+.audit-history__item {
+  position: relative;
+  padding-left: 1.35rem;
+}
+
+.audit-history__dot {
+  position: absolute;
+  top: 0.9rem;
+  left: 0.15rem;
+  width: 0.62rem;
+  height: 0.62rem;
+  border-radius: 50%;
+  background: #6b7280;
+  border: 2px solid #090b0d;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.06);
+}
+
+.audit-history__dot[data-action='created'] {
+  background: #22c55e;
+}
+
+.audit-history__dot[data-action='updated'] {
+  background: #3b82f6;
+}
+
+.audit-history__dot[data-action='deleted'] {
+  background: #ef4444;
+}
+
+.audit-history__dot[data-action='restored'] {
+  background: #a78bfa;
+}
+
+.audit-history__dot[data-action='analyzed'] {
+  background: #60a5fa;
+}
+
+.audit-history__dot[data-action='exported'],
+.audit-history__dot[data-action='imported'] {
+  background: #22d3ee;
 }
 
 .audit-history__row {
-  border: 1px solid #e5e7eb;
-  border-radius: 0.75rem;
-  padding: 0.875rem 1rem;
-  background: #fff;
-}
-
-.audit-history__meta {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  margin-bottom: 0.35rem;
-  font-size: 0.875rem;
-  color: #4b5563;
+  flex-direction: column;
+  gap: 0.56rem;
+  padding: 0.8rem 0.95rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  background: linear-gradient(180deg, rgba(17, 19, 22, 0.96) 0%, rgba(12, 14, 16, 0.96) 100%);
 }
 
-.audit-history__action,
-.audit-history__resource {
+.audit-history__row-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.85rem;
+}
+
+.audit-history__pills {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.audit-history__action-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.17rem 0.5rem;
+  border-radius: 0.45rem;
+  border: 1px solid transparent;
+  font-size: 0.6875rem;
   font-weight: 600;
-  color: #111827;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.audit-history__action-pill[data-action='created'] {
+  background: #103320;
+  color: #bbf7d0;
+}
+
+.audit-history__action-pill[data-action='updated'] {
+  background: #112f53;
+  color: #dbeafe;
+}
+
+.audit-history__action-pill[data-action='deleted'] {
+  background: #3f1111;
+  color: #fee2e2;
+}
+
+.audit-history__action-pill[data-action='restored'] {
+  background: #2f1b46;
+  color: #f3e8ff;
+}
+
+.audit-history__action-pill[data-action='analyzed'] {
+  background: #15324f;
+  color: #dbeafe;
+}
+
+.audit-history__action-pill[data-action='exported'],
+.audit-history__action-pill[data-action='imported'] {
+  background: #113341;
+  color: #cffafe;
+}
+
+.audit-history__resource-type {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.42rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #737b87;
+  font-size: 0.6875rem;
+  text-transform: lowercase;
+}
+
+.audit-history__resource-block {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  min-width: 0;
+  gap: 0.2rem;
+  text-align: right;
+}
+
+.audit-history__time {
+  font-size: 0.75rem;
+  color: #7d8692;
+  font-variant-numeric: tabular-nums;
+}
+
+.audit-history__resource {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #fbfbfb;
+  max-width: 15rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-history__summary {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: #d2d6db;
+}
+
+.audit-history__row-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.audit-history__actor {
+  font-size: 0.75rem;
+  color: #7c8591;
+}
+
+.audit-history__actor strong {
+  color: #14b8a6;
+  font-weight: 600;
+}
+
+.audit-history__restore {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.62rem;
+  border-radius: 7px;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  background: #123423;
+  color: #bbf7d0;
+  font: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.audit-history__restore:hover {
+  background: rgba(34, 197, 94, 0.14);
+}
+
+.audit-history__status,
+.audit-history__empty {
+  margin: 0;
+  font-size: 0.8125rem;
+}
+
+.audit-history__status {
+  padding: 0.75rem 1rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #161a1f;
+  color: #d0dae6;
+}
+
+.audit-history__status--error {
+  border-color: rgba(248, 113, 113, 0.35);
+  background: rgba(127, 29, 29, 0.18);
+  color: #fecaca;
+}
+
+.audit-history__empty {
+  padding: 1rem;
+  border-radius: 10px;
+  border: 1px dashed rgba(255, 255, 255, 0.14);
+  color: #7f8893;
+  text-align: center;
 }
 
 .audit-history__load-more {
-  align-self: flex-start;
+  align-self: center;
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.875rem;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: #1a1f25;
+  color: #eef2f7;
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.audit-history__load-more:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.audit-history__load-more:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+@media (max-width: 900px) {
+  .audit-history__body {
+    padding-inline: 1rem;
+  }
+
+  .audit-history__row-head {
+    flex-wrap: wrap;
+  }
+
+  .audit-history__resource-block {
+    align-items: flex-start;
+    text-align: left;
+  }
+
+  .audit-history__resource {
+    max-width: 100%;
+  }
+
+  .audit-history__filters,
+  .audit-history__groups {
+    width: 100%;
+  }
 }

--- a/apps/web/src/app/features/audit-history/audit-history.component.html
+++ b/apps/web/src/app/features/audit-history/audit-history.component.html
@@ -1,41 +1,97 @@
 <section class="audit-history" aria-label="Audit history">
   <header class="audit-history__head">
-    <div>
+    <div class="audit-history__titles">
       <h1 class="audit-history__title">Audit history</h1>
       <p class="audit-history__sub">Recent management changes for this project.</p>
     </div>
+    @if (!loading() && !errorMessage() && entries().length > 0) {
+      <span class="audit-history__count"
+        >{{ entries().length }} {{ entries().length === 1 ? 'entry' : 'entries' }}</span
+      >
+    }
   </header>
 
-  @if (loading()) {
-    <p class="audit-history__status">Loading audit history...</p>
-  } @else if (errorMessage(); as errorMessage) {
-    <p class="audit-history__status audit-history__status--error">{{ errorMessage }}</p>
-  } @else if (entries().length === 0) {
-    <p class="audit-history__status">{{ emptyStateMessage() }}</p>
-  } @else {
-    <ul class="audit-history__list">
-      @for (entry of entries(); track entry.id) {
-        <li class="audit-history__row">
-          <div class="audit-history__meta">
-            <span class="audit-history__time">{{ entry.timeLabel }}</span>
-            <span class="audit-history__actor">{{ entry.actorLabel }}</span>
-            <span class="audit-history__action">{{ entry.actionLabel }}</span>
-            <span class="audit-history__resource">{{ entry.resourceLabel }}</span>
-          </div>
-          <p class="audit-history__summary">{{ entry.summary }}</p>
-          @if (canRestoreEntry(entry)) {
-            <button type="button" class="audit-history__load-more" (click)="requestRestore(entry)">
-              Restore snapshot
-            </button>
-          }
-        </li>
-      }
-    </ul>
+  <div class="audit-history__body cp-scrollbar">
+    @if (loading()) {
+      <p class="audit-history__status">Loading audit history…</p>
+    } @else if (errorMessage(); as errorMessage) {
+      <p class="audit-history__status audit-history__status--error">{{ errorMessage }}</p>
+    } @else if (entries().length === 0) {
+      <p class="audit-history__empty">{{ emptyStateMessage() }}</p>
+    } @else {
+      <div class="audit-history__filters" role="tablist" aria-label="History filters">
+        @for (filter of actionFilters(); track filter) {
+          <button
+            type="button"
+            class="audit-history__filter"
+            [class.audit-history__filter--active]="isFilterActive(filter)"
+            [attr.aria-pressed]="isFilterActive(filter)"
+            (click)="setFilter(filter)"
+          >
+            {{ filterLabel(filter) }}
+          </button>
+        }
+      </div>
 
-    @if (olderHistoryAvailable()) {
-      <button type="button" class="audit-history__load-more" (click)="loadOlder()" [disabled]="loadingOlder()">
-        {{ loadingOlder() ? 'Loading…' : 'Load older history' }}
-      </button>
+      @if (groupedEntries().length === 0) {
+        <p class="audit-history__empty">No entries match this filter.</p>
+      } @else {
+        <div class="audit-history__groups">
+          @for (group of groupedEntries(); track group.key) {
+            <section class="audit-history__group" [attr.aria-label]="group.label">
+              <header class="audit-history__group-head">
+                <span class="audit-history__group-label">{{ group.label }}</span>
+                <span class="audit-history__group-count">{{ group.items.length }}</span>
+              </header>
+
+              <ol class="audit-history__list">
+                @for (entry of group.items; track entry.id) {
+                  <li class="audit-history__item">
+                    <span class="audit-history__dot" [attr.data-action]="entry.action" aria-hidden="true"></span>
+                    <article class="audit-history__row">
+                      <div class="audit-history__row-head">
+                        <div class="audit-history__pills">
+                          <span class="audit-history__action-pill" [attr.data-action]="entry.action">
+                            {{ entry.actionLabel }}
+                          </span>
+                          <span class="audit-history__resource-type" [attr.data-resource]="entry.resourceType">
+                            {{ entry.resourceType }}
+                          </span>
+                        </div>
+                        <div class="audit-history__resource-block">
+                          <time class="audit-history__time" [attr.datetime]="entry.createdAt">{{
+                            entry.timeLabel
+                          }}</time>
+                          <span class="audit-history__resource" [title]="entry.resourceLabel">{{
+                            entry.resourceLabel
+                          }}</span>
+                        </div>
+                      </div>
+                      <p class="audit-history__summary">{{ entry.summary }}</p>
+                      <div class="audit-history__row-foot">
+                        <span class="audit-history__actor"
+                          >By <strong>{{ entry.actorLabel }}</strong></span
+                        >
+                        @if (canRestoreEntry(entry)) {
+                          <button type="button" class="audit-history__restore" (click)="requestRestore(entry)">
+                            Restore snapshot
+                          </button>
+                        }
+                      </div>
+                    </article>
+                  </li>
+                }
+              </ol>
+            </section>
+          }
+        </div>
+      }
+
+      @if (olderHistoryAvailable()) {
+        <button type="button" class="audit-history__load-more" (click)="loadOlder()" [disabled]="loadingOlder()">
+          {{ loadingOlder() ? 'Loading…' : 'Load older history' }}
+        </button>
+      }
     }
-  }
+  </div>
 </section>

--- a/apps/web/src/app/features/audit-history/audit-history.component.spec.ts
+++ b/apps/web/src/app/features/audit-history/audit-history.component.spec.ts
@@ -132,12 +132,26 @@ describe('AuditHistoryComponent', () => {
   });
 
   it('loads older history with tuple cursors and merges entries without duplicates', async () => {
+    const initialItems: AuditHistoryEntry[] = [
+      newestEntry,
+      olderEntry,
+      ...Array.from({ length: 23 }, (_, index) => {
+        const minute = String(59 - index).padStart(2, '0');
+        return {
+          ...olderEntry,
+          id: `audit-seed-${index}`,
+          createdAt: `2026-04-14T11:${minute}:00.000Z`,
+          timeLabel: `11:${minute}:00`,
+        };
+      }),
+    ];
+    const initialCursor = initialItems.at(-1)!;
     const listEvents = vi
       .fn<AuditHistoryRepository['listEvents']>()
-      .mockResolvedValueOnce(createListResponse([newestEntry, olderEntry]))
+      .mockResolvedValueOnce(createListResponse(initialItems))
       .mockResolvedValueOnce({
         items: [
-          olderEntry,
+          initialCursor,
           { ...olderEntry, id: 'audit-0', createdAt: '2026-04-14T12:00:00.000Z', timeLabel: '12:00:00' },
         ],
         nextCursor: { createdAt: '2026-04-14T12:00:00.000Z', id: 'audit-0' },
@@ -167,11 +181,13 @@ describe('AuditHistoryComponent', () => {
     await flushAsyncWork();
 
     expect(listEvents).toHaveBeenNthCalledWith(2, 'project-1', {
+      limit: 25,
       direction: 'older',
-      cursorCreatedAt: '2026-04-14T12:00:01.000Z',
-      cursorId: 'audit-1',
+      cursorCreatedAt: initialCursor.createdAt,
+      cursorId: initialCursor.id,
     });
-    expect(component.entries().map((entry) => entry.id)).toEqual(['audit-2', 'audit-1', 'audit-0']);
+    expect(component.entries().some((entry) => entry.id === 'audit-0')).toBe(true);
+    expect(component.entries().length).toBe(26);
     expect(component.loadingOlder()).toBe(false);
   });
 

--- a/apps/web/src/app/features/audit-history/audit-history.component.ts
+++ b/apps/web/src/app/features/audit-history/audit-history.component.ts
@@ -1,6 +1,23 @@
-import { ChangeDetectionStrategy, Component, effect, inject, input, output, signal, untracked } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+  untracked,
+} from '@angular/core';
 import { AuditHistoryRepository } from './data-access/audit-history.repository';
-import type { AuditHistoryCursor, AuditHistoryEntry } from './models/audit-history.model';
+import type {
+  AuditAction,
+  AuditHistoryCursor,
+  AuditHistoryEntry,
+  AuditHistoryListResult,
+} from './models/audit-history.model';
+
+const AUDIT_HISTORY_PAGE_SIZE = 25;
 
 function compareEntries(left: AuditHistoryEntry, right: AuditHistoryEntry): number {
   const timeDelta = new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime();
@@ -12,6 +29,34 @@ function mergeEntries(current: AuditHistoryEntry[], incoming: AuditHistoryEntry[
   const byId = new Map(current.map((entry) => [entry.id, entry]));
   for (const entry of incoming) byId.set(entry.id, entry);
   return [...byId.values()].sort(compareEntries);
+}
+
+function hasOlderHistory(response: AuditHistoryListResult): boolean {
+  return response.nextCursor !== null && response.items.length >= AUDIT_HISTORY_PAGE_SIZE;
+}
+
+type AuditActionFilter = 'all' | AuditAction;
+
+interface AuditTimelineGroup {
+  key: string;
+  label: string;
+  items: AuditHistoryEntry[];
+}
+
+function startOfLocalDay(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+function buildGroupLabel(createdAt: string, now = new Date()): string {
+  const eventDate = new Date(createdAt);
+  const dayDelta = Math.floor((startOfLocalDay(now) - startOfLocalDay(eventDate)) / 86400000);
+  if (dayDelta === 0) return 'Today';
+  if (dayDelta === 1) return 'Yesterday';
+  return eventDate.toLocaleDateString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
 }
 
 @Component({
@@ -34,7 +79,41 @@ export class AuditHistoryComponent {
   protected readonly loadingOlder = signal(false);
   protected readonly errorMessage = signal<string | null>(null);
   protected readonly olderHistoryAvailable = signal(false);
+  protected readonly activeFilter = signal<AuditActionFilter>('all');
   private readonly olderCursor = signal<AuditHistoryCursor | null>(null);
+  protected readonly actionFilters = computed<AuditActionFilter[]>(() => {
+    const usedActions = new Set(this.entries().map((entry) => entry.action));
+    const preferredOrder: AuditAction[] = [
+      'created',
+      'updated',
+      'deleted',
+      'restored',
+      'analyzed',
+      'exported',
+      'imported',
+    ];
+    const ordered = preferredOrder.filter((action) => usedActions.has(action));
+    return ['all', ...ordered];
+  });
+  protected readonly filteredEntries = computed(() => {
+    const filter = this.activeFilter();
+    if (filter === 'all') return this.entries();
+    return this.entries().filter((entry) => entry.action === filter);
+  });
+  protected readonly groupedEntries = computed<AuditTimelineGroup[]>(() => {
+    const groups = new Map<string, AuditTimelineGroup>();
+    for (const entry of this.filteredEntries()) {
+      const groupLabel = buildGroupLabel(entry.createdAt);
+      const key = `${groupLabel}|${entry.createdAt.slice(0, 10)}`;
+      const group = groups.get(key);
+      if (group) {
+        group.items.push(entry);
+      } else {
+        groups.set(key, { key, label: groupLabel, items: [entry] });
+      }
+    }
+    return [...groups.values()];
+  });
 
   constructor() {
     effect(() => {
@@ -46,6 +125,16 @@ export class AuditHistoryComponent {
   }
 
   protected readonly emptyStateMessage = () => 'No audit history yet for this project.';
+  protected readonly filterLabel = (filter: AuditActionFilter): string =>
+    filter === 'all' ? 'All' : filter.charAt(0).toUpperCase() + filter.slice(1);
+
+  protected isFilterActive(filter: AuditActionFilter): boolean {
+    return this.activeFilter() === filter;
+  }
+
+  protected setFilter(filter: AuditActionFilter): void {
+    this.activeFilter.set(filter);
+  }
 
   protected canRestoreEntry(entry: AuditHistoryEntry): boolean {
     return this.canRestoreSnapshots() && entry.resourceType === 'snapshot';
@@ -59,15 +148,16 @@ export class AuditHistoryComponent {
   async loadProject(projectId: string): Promise<void> {
     this.loading.set(true);
     this.errorMessage.set(null);
+    this.activeFilter.set('all');
     this.entries.set([]);
     this.olderCursor.set(null);
     this.olderHistoryAvailable.set(false);
 
     try {
-      const response = await this.repository.listEvents(projectId, {});
+      const response = await this.repository.listEvents(projectId, { limit: AUDIT_HISTORY_PAGE_SIZE });
       this.entries.set(response.items);
       this.olderCursor.set(response.nextCursor);
-      this.olderHistoryAvailable.set(response.nextCursor !== null && response.items.length > 0);
+      this.olderHistoryAvailable.set(hasOlderHistory(response));
     } catch (error) {
       this.errorMessage.set(error instanceof Error ? error.message : 'Could not load audit history.');
     } finally {
@@ -89,13 +179,14 @@ export class AuditHistoryComponent {
 
     try {
       const response = await this.repository.listEvents(projectId, {
+        limit: AUDIT_HISTORY_PAGE_SIZE,
         direction: 'older',
         cursorCreatedAt: cursor.createdAt,
         cursorId: cursor.id,
       });
       this.entries.update((current) => mergeEntries(current, response.items));
       this.olderCursor.set(response.nextCursor);
-      this.olderHistoryAvailable.set(response.nextCursor !== null && response.items.length > 0);
+      this.olderHistoryAvailable.set(hasOlderHistory(response));
     } catch (error) {
       this.errorMessage.set(error instanceof Error ? error.message : 'Could not load audit history.');
     } finally {


### PR DESCRIPTION
Closes #69

## Summary
- Rediseña audit history como timeline agrupado por día con tarjetas más densas.
- Añade filtros por tipo de acción para inspección rápida de eventos.
- Ajusta paginación `older` para evitar duplicados y mantener límites estables.

## Test plan
- [x] `pnpm --dir apps/web test -- src/app/features/audit-history/audit-history.component.spec.ts`


Made with [Cursor](https://cursor.com)