### PR TITLE
fix(backend): protect personal workspace owner membership

### DIFF
--- a/apps/backend/src/__tests__/app.integration.test.ts
+++ b/apps/backend/src/__tests__/app.integration.test.ts
@@ -529,6 +529,7 @@ describe('app integration', () => {
       expect(response.body.project.workspace).toEqual({
         id: 'workspace-1',
         role: 'viewer',
+        isPersonal: true,
         capabilities: { canEdit: false, canManageMembers: false },
       });
     } finally {
@@ -572,6 +573,7 @@ describe('app integration', () => {
     expect(response.body.workspace).toEqual({
       id: 'workspace-1',
       role: 'editor',
+      isPersonal: true,
       capabilities: { canEdit: true, canManageMembers: false },
     });
   });
@@ -824,6 +826,7 @@ describe('app integration', () => {
         workspace: {
           id: 'workspace-1',
           role: 'owner',
+          isPersonal: true,
           capabilities: { canEdit: true, canManageMembers: true },
         },
         updatedAt: '2026-04-08T10:00:00.000Z',
@@ -990,6 +993,17 @@ describe('app integration', () => {
         },
       },
     });
+  });
+
+  it('bloquea remover la propia membresía del personal workspace', async () => {
+    const response = await request(app)
+      .delete('/api/v1/workspaces/workspace-1/members/user-1')
+      .set(authHeaders());
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('PERSONAL_WORKSPACE_OWNER_MEMBERSHIP_REQUIRED');
+    expect(prismaMock.workspaceMembership.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.workspaceMembership.delete).not.toHaveBeenCalled();
   });
 
   it('GET /api/v1/projects/:projectId/dashboard-summary responde 404 cuando falta el proyecto', async () => {

--- a/apps/backend/src/auth/authorization.ts
+++ b/apps/backend/src/auth/authorization.ts
@@ -105,6 +105,7 @@ export function resolveWorkspaceAccess(
   return {
     id: resolvedWorkspaceId,
     role: membership.role,
+    isPersonal: actor.personalWorkspaceId === resolvedWorkspaceId,
     capabilities: getWorkspaceCapabilities(membership.role),
   };
 }

--- a/apps/backend/src/auth/types.ts
+++ b/apps/backend/src/auth/types.ts
@@ -23,6 +23,7 @@ export interface WorkspaceCapabilities {
 export interface WorkspaceAccessSummary {
   id: string;
   role: WorkspaceRole;
+  isPersonal: boolean;
   capabilities: WorkspaceCapabilities;
 }
 

--- a/apps/backend/src/management/dashboard/schema.ts
+++ b/apps/backend/src/management/dashboard/schema.ts
@@ -14,6 +14,7 @@ export const workspaceCapabilitiesSchema = z.object({
 export const workspaceSummarySchema = z.object({
   id: z.string(),
   role: workspaceRoleSchema,
+  isPersonal: z.boolean(),
   capabilities: workspaceCapabilitiesSchema,
 });
 

--- a/apps/backend/src/management/dashboard/service.test.ts
+++ b/apps/backend/src/management/dashboard/service.test.ts
@@ -17,6 +17,7 @@ describe('dashboard/service', () => {
         workspace: {
           id: 'workspace-1',
           role: 'owner',
+          isPersonal: true,
           capabilities: { canEdit: true, canManageMembers: true },
         },
         updatedAt: new Date('2026-04-08T10:00:00.000Z'),
@@ -176,6 +177,7 @@ describe('dashboard/service', () => {
         workspace: {
           id: 'workspace-1',
           role: 'viewer',
+          isPersonal: false,
           capabilities: { canEdit: false, canManageMembers: false },
         },
         updatedAt: new Date('2026-04-08T10:00:00.000Z'),

--- a/apps/backend/src/management/global-config/service.test.ts
+++ b/apps/backend/src/management/global-config/service.test.ts
@@ -15,6 +15,7 @@ describe('global-config/service', () => {
         workspace: {
           id: 'workspace-1',
           role: 'owner',
+          isPersonal: true,
           capabilities: {
             canEdit: true,
             canManageMembers: true,

--- a/apps/backend/src/management/workspace-members/service.ts
+++ b/apps/backend/src/management/workspace-members/service.ts
@@ -128,6 +128,12 @@ export async function removeWorkspaceMember(
 ): Promise<void> {
   requireWorkspaceAccess(actor, workspaceId, 'owner');
 
+  if (actor.personalWorkspaceId === workspaceId && actor.userId === memberUserId) {
+    throw new AppError(409, 'Personal workspace owners must keep their own membership', {
+      code: 'PERSONAL_WORKSPACE_OWNER_MEMBERSHIP_REQUIRED',
+    });
+  }
+
   const membership = await prisma.workspaceMembership.findUnique({
     where: {
       workspaceId_userId: {


### PR DESCRIPTION
Closes #70

## Summary
- Añade `isPersonal` al resumen de acceso de workspace para contexto explícito en servicios de management.
- Bloquea intentos de auto-remoción del owner en personal workspace con código de error dedicado.
- Ajusta tests de dashboard/global-config para el nuevo shape de workspace summary.

## Test plan
- [x] `pnpm --dir apps/backend test -- src/management/dashboard/service.test.ts src/management/global-config/service.test.ts src/management/workspace-members/service.test.ts`


Made with [Cursor](https://cursor.com)