### PR TITLE
feat(backend): workspaces, invitations, and workspace-aware domain

### DIFF
--- a/apps/backend/prisma/migrations/20260426092500_workspace_invitations/migration.sql
+++ b/apps/backend/prisma/migrations/20260426092500_workspace_invitations/migration.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "WorkspaceInvitation" (
+  "id" TEXT NOT NULL,
+  "workspaceId" TEXT NOT NULL,
+  "email" TEXT NOT NULL,
+  "role" TEXT NOT NULL DEFAULT 'viewer',
+  "status" TEXT NOT NULL DEFAULT 'pending',
+  "invitedByUserId" TEXT NOT NULL,
+  "acceptedByUserId" TEXT,
+  "acceptedAt" TIMESTAMP(3),
+  "revokedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "WorkspaceInvitation_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "WorkspaceInvitation"
+ADD CONSTRAINT "WorkspaceInvitation_workspaceId_fkey"
+FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE INDEX "WorkspaceInvitation_workspaceId_status_createdAt_id_idx"
+ON "WorkspaceInvitation"("workspaceId", "status", "createdAt" DESC, "id" DESC);
+
+CREATE INDEX "WorkspaceInvitation_email_status_createdAt_id_idx"
+ON "WorkspaceInvitation"("email", "status", "createdAt" DESC, "id" DESC);
+
+CREATE UNIQUE INDEX "WorkspaceInvitation_pending_workspace_email_key"
+ON "WorkspaceInvitation"("workspaceId", "email")
+WHERE "status" = 'pending';

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -49,7 +49,27 @@ model Workspace {
 
   personalForUser User?                  @relation("PersonalWorkspaceOwner", fields: [personalForUserId], references: [id], onDelete: SetNull)
   memberships     WorkspaceMembership[]
+  invitations     WorkspaceInvitation[]
   projects        Project[]
+}
+
+model WorkspaceInvitation {
+  id               String   @id @default(cuid())
+  workspaceId      String
+  email            String
+  role             String   @default("viewer")
+  status           String   @default("pending")
+  invitedByUserId  String
+  acceptedByUserId String?
+  acceptedAt       DateTime?
+  revokedAt        DateTime?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@index([workspaceId, status, createdAt(sort: Desc), id(sort: Desc)])
+  @@index([email, status, createdAt(sort: Desc), id(sort: Desc)])
 }
 
 model WorkspaceMembership {

--- a/apps/backend/src/__tests__/app.integration.test.ts
+++ b/apps/backend/src/__tests__/app.integration.test.ts
@@ -22,9 +22,19 @@ const prismaMock = {
   },
   workspaceMembership: {
     findMany: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    count: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+  workspaceInvitation: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
     findUnique: vi.fn(),
     create: vi.fn(),
-    delete: vi.fn(),
+    update: vi.fn(),
   },
   externalIdentity: {
     findUnique: vi.fn(),
@@ -208,6 +218,7 @@ describe('app integration', () => {
     resetNestedMocks(prismaMock.user);
     resetNestedMocks(prismaMock.workspace);
     resetNestedMocks(prismaMock.workspaceMembership);
+    resetNestedMocks(prismaMock.workspaceInvitation);
     resetNestedMocks(prismaMock.externalIdentity);
     resetNestedMocks(prismaMock.project);
     resetNestedMocks(prismaMock.endpoint);
@@ -467,8 +478,102 @@ describe('app integration', () => {
     expect(tx.globalConfig.create).toHaveBeenCalledTimes(1);
   });
 
+  it('POST /api/v1/projects acepta workspaceId explícito cuando el actor puede mutar ese workspace', async () => {
+    const actorIdentity = buildActorIdentity('owner');
+    prismaMock.externalIdentity.findUnique.mockResolvedValueOnce({
+      ...actorIdentity,
+      user: {
+        ...actorIdentity.user,
+        memberships: [
+          { workspaceId: 'workspace-1', role: 'owner' },
+          { workspaceId: 'workspace-2', role: 'editor' },
+        ],
+      },
+    });
+    prismaMock.project.findMany.mockResolvedValueOnce([]);
+
+    const tx = {
+      project: {
+        create: vi.fn().mockResolvedValue({
+          id: 'p2',
+          workspaceId: 'workspace-2',
+          name: 'Equipo API',
+          slug: 'equipo-api',
+          description: '',
+        }),
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: 'p2',
+          workspaceId: 'workspace-2',
+          name: 'Equipo API',
+          slug: 'equipo-api',
+          description: '',
+          workspace: {
+            id: 'workspace-2',
+            name: 'Equipo Plataforma',
+            kind: 'team',
+          },
+          globalConfig: { projectId: 'p2' },
+          _count: { endpoints: 0 },
+        }),
+      },
+      globalConfig: {
+        create: vi.fn().mockResolvedValue({ id: 'gc2' }),
+      },
+      user: {
+        findUnique: vi.fn().mockResolvedValue({
+          email: 'owner@example.com',
+          displayName: 'Owner User',
+        }),
+      },
+      auditEvent: {
+        create: vi.fn().mockResolvedValue({ id: 'audit-2' }),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementationOnce(async (callback) => callback(tx));
+
+    const response = await request(app)
+      .post('/api/v1/projects')
+      .set(authHeaders())
+      .send({ name: 'Equipo API', workspaceId: 'workspace-2' });
+
+    expect(response.status).toBe(201);
+    expect(tx.project.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ workspaceId: 'workspace-2' }),
+      })
+    );
+    expect(response.body.workspace).toEqual({
+      id: 'workspace-2',
+      name: 'Equipo Plataforma',
+      kind: 'team',
+      role: 'editor',
+      isPersonal: false,
+      capabilities: {
+        canEdit: true,
+        canManageMembers: false,
+        canRestoreSnapshots: false,
+        canImportContracts: false,
+      },
+    });
+  });
+
+  it('POST /api/v1/projects rechaza workspaceId explícito sin permisos de mutación', async () => {
+    prismaMock.externalIdentity.findUnique.mockResolvedValueOnce(buildActorIdentity('viewer'));
+
+    const response = await request(app)
+      .post('/api/v1/projects')
+      .set(authHeaders())
+      .send({ name: 'Sin permiso', workspaceId: 'workspace-1' });
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('WORKSPACE_MUTATION_DENIED');
+    expect(prismaMock.project.create).not.toHaveBeenCalled();
+  });
+
   it('PATCH /api/v1/projects/:projectId actualiza metadata sin cambiar slug', async () => {
     prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+    prismaMock.project.findUniqueOrThrow.mockResolvedValueOnce({ slug: 'mi-api' });
     prismaMock.project.update.mockResolvedValueOnce({
       id: 'p1',
       workspaceId: 'workspace-1',
@@ -489,6 +594,253 @@ describe('app integration', () => {
     expect(response.body.slug).toBe('mi-api');
   });
 
+  it('PATCH /api/v1/projects/:projectId permite actualizar slug y devuelve nueva mock URL en dashboard', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+    prismaMock.project.findUniqueOrThrow.mockResolvedValueOnce({ slug: 'mi-api' });
+    prismaMock.project.findUnique.mockResolvedValueOnce(null);
+    prismaMock.project.update.mockResolvedValueOnce({
+      id: 'p1',
+      workspaceId: 'workspace-1',
+      name: 'Mi API',
+      slug: 'mi-api-v2',
+      description: 'Nuevo texto',
+      globalConfig: { projectId: 'p1' },
+      _count: { endpoints: 0 },
+    });
+
+    const response = await request(app)
+      .patch('/api/v1/projects/p1')
+      .set(authHeaders())
+      .send({ slug: 'Mi API v2' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.slug).toBe('mi-api-v2');
+    expect(prismaMock.project.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ slug: 'mi-api-v2' }),
+      })
+    );
+  });
+
+  it('PATCH /api/v1/projects/:projectId transfiere el proyecto entre workspaces y registra metadata de auditoría clara', async () => {
+    const actorIdentity = buildActorIdentity('owner');
+    prismaMock.externalIdentity.findUnique.mockResolvedValueOnce({
+      ...actorIdentity,
+      user: {
+        ...actorIdentity.user,
+        memberships: [
+          { workspaceId: 'workspace-1', role: 'owner' },
+          { workspaceId: 'workspace-2', role: 'editor' },
+        ],
+      },
+    });
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+
+    const tx = {
+      project: {
+        findUniqueOrThrow: vi
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'p1',
+            slug: 'mi-api',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Personal workspace', kind: 'personal' },
+          })
+          .mockResolvedValueOnce({
+            id: 'p1',
+            workspaceId: 'workspace-2',
+            name: 'Mi API trasladada',
+            slug: 'mi-api',
+            description: 'Nuevo workspace',
+            workspace: { id: 'workspace-2', name: 'Equipo Plataforma', kind: 'team' },
+            globalConfig: { projectId: 'p1' },
+            _count: { endpoints: 0 },
+          }),
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn().mockResolvedValue({
+          id: 'p1',
+          workspaceId: 'workspace-2',
+          name: 'Mi API trasladada',
+          slug: 'mi-api',
+          description: 'Nuevo workspace',
+          workspace: { id: 'workspace-2', name: 'Equipo Plataforma', kind: 'team' },
+          globalConfig: { projectId: 'p1' },
+          _count: { endpoints: 0 },
+        }),
+      },
+      user: {
+        findUnique: vi.fn().mockResolvedValue({
+          email: 'owner@example.com',
+          displayName: 'Owner User',
+        }),
+      },
+      auditEvent: {
+        create: vi.fn().mockResolvedValue({ id: 'audit-transfer' }),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementationOnce(async (callback) => callback(tx));
+
+    const response = await request(app)
+      .patch('/api/v1/projects/p1')
+      .set(authHeaders())
+      .send({
+        name: 'Mi API trasladada',
+        description: 'Nuevo workspace',
+        workspaceId: 'workspace-2',
+      });
+
+    expect(response.status).toBe(200);
+    expect(tx.project.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ workspaceId: 'workspace-2' }),
+      })
+    );
+    expect(tx.auditEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          workspaceId: 'workspace-2',
+          metadata: expect.objectContaining({
+            previousWorkspaceId: 'workspace-1',
+            previousWorkspaceName: 'Personal workspace',
+            nextWorkspaceId: 'workspace-2',
+            nextWorkspaceName: 'Equipo Plataforma',
+          }),
+        }),
+      })
+    );
+    expect(response.body.workspace).toEqual({
+      id: 'workspace-2',
+      name: 'Equipo Plataforma',
+      kind: 'team',
+      role: 'editor',
+      isPersonal: false,
+      capabilities: {
+        canEdit: true,
+        canManageMembers: false,
+        canRestoreSnapshots: false,
+        canImportContracts: false,
+      },
+    });
+  });
+
+  it('PATCH /api/v1/projects/:projectId rechaza transferencias a workspaces destino sin permisos de mutación', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+
+    const response = await request(app)
+      .patch('/api/v1/projects/p1')
+      .set(authHeaders())
+      .send({ workspaceId: 'workspace-2' });
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('WORKSPACE_ACCESS_DENIED');
+    expect(prismaMock.project.update).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /api/v1/projects/:projectId trata workspaceId igual al actual como no-op de transferencia', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+
+    const tx = {
+      project: {
+        findUniqueOrThrow: vi
+          .fn()
+          .mockResolvedValueOnce({
+            id: 'p1',
+            slug: 'mi-api',
+            workspaceId: 'workspace-1',
+            workspace: { id: 'workspace-1', name: 'Personal workspace', kind: 'personal' },
+          })
+          .mockResolvedValueOnce({
+            id: 'p1',
+            workspaceId: 'workspace-1',
+            name: 'Mi API v2',
+            slug: 'mi-api',
+            description: 'Sin traslado',
+            workspace: { id: 'workspace-1', name: 'Personal workspace', kind: 'personal' },
+            globalConfig: { projectId: 'p1' },
+            _count: { endpoints: 0 },
+          }),
+        findUnique: vi.fn().mockResolvedValue(null),
+        update: vi.fn().mockResolvedValue({
+          id: 'p1',
+          workspaceId: 'workspace-1',
+          name: 'Mi API v2',
+          slug: 'mi-api',
+          description: 'Sin traslado',
+          workspace: { id: 'workspace-1', name: 'Personal workspace', kind: 'personal' },
+          globalConfig: { projectId: 'p1' },
+          _count: { endpoints: 0 },
+        }),
+      },
+      user: {
+        findUnique: vi.fn().mockResolvedValue({
+          email: 'owner@example.com',
+          displayName: 'Owner User',
+        }),
+      },
+      auditEvent: {
+        create: vi.fn().mockResolvedValue({ id: 'audit-noop' }),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementationOnce(async (callback) => callback(tx));
+
+    const response = await request(app)
+      .patch('/api/v1/projects/p1')
+      .set(authHeaders())
+      .send({ name: 'Mi API v2', description: 'Sin traslado', workspaceId: 'workspace-1' });
+
+    expect(response.status).toBe(200);
+    expect(tx.project.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.not.objectContaining({ workspaceId: expect.any(String) }),
+      })
+    );
+    expect(tx.auditEvent.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: expect.not.objectContaining({
+            previousWorkspaceId: expect.any(String),
+            nextWorkspaceId: expect.any(String),
+          }),
+        }),
+      })
+    );
+  });
+
+  it('PATCH /api/v1/projects/:projectId responde 409 cuando el slug ya existe', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+    prismaMock.project.findUniqueOrThrow.mockResolvedValueOnce({ slug: 'mi-api' });
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p2' });
+
+    const response = await request(app)
+      .patch('/api/v1/projects/p1')
+      .set(authHeaders())
+      .send({ slug: 'other-api' });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      error: 'Project slug already exists',
+      code: 'PROJECT_SLUG_DUPLICATE',
+    });
+  });
+
+  it('PATCH /api/v1/projects/:projectId responde 409 cuando el slug está reservado', async () => {
+    prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+    prismaMock.project.findUniqueOrThrow.mockResolvedValueOnce({ slug: 'mi-api' });
+
+    const response = await request(app)
+      .patch('/api/v1/projects/p1')
+      .set(authHeaders())
+      .send({ slug: 'mock' });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      error: 'Project slug is reserved',
+      code: 'PROJECT_SLUG_RESERVED',
+    });
+  });
+
   it('permite a viewer acceder a dashboard summary y expone rol/capabilities del workspace', async () => {
     prismaMock.externalIdentity.findUnique.mockResolvedValueOnce(buildActorIdentity('viewer'));
     const { env } = await import('../config/env.js');
@@ -499,6 +851,7 @@ describe('app integration', () => {
       prismaMock.project.findUnique.mockResolvedValueOnce({
         id: 'p1',
         workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Personal workspace', kind: 'personal' },
         name: 'Proyecto',
         slug: 'proyecto',
         description: 'Demo',
@@ -528,9 +881,16 @@ describe('app integration', () => {
       expect(response.status).toBe(200);
       expect(response.body.project.workspace).toEqual({
         id: 'workspace-1',
+        name: 'Personal workspace',
+        kind: 'personal',
         role: 'viewer',
         isPersonal: true,
-        capabilities: { canEdit: false, canManageMembers: false },
+        capabilities: {
+          canEdit: false,
+          canManageMembers: false,
+          canRestoreSnapshots: false,
+          canImportContracts: false,
+        },
       });
     } finally {
       env.MOCK_BASE_URL = originalMockBaseUrl;
@@ -554,9 +914,11 @@ describe('app integration', () => {
   it('permite mutaciones de proyecto para editor', async () => {
     prismaMock.externalIdentity.findUnique.mockResolvedValueOnce(buildActorIdentity('editor'));
     prismaMock.project.findUnique.mockResolvedValueOnce({ id: 'p1', workspaceId: 'workspace-1' });
+    prismaMock.project.findUniqueOrThrow.mockResolvedValueOnce({ slug: 'mi-api' });
     prismaMock.project.update.mockResolvedValueOnce({
       id: 'p1',
       workspaceId: 'workspace-1',
+      workspace: { id: 'workspace-1', name: 'Personal workspace', kind: 'personal' },
       name: 'Editado',
       slug: 'mi-api',
       description: 'Nuevo texto',
@@ -572,9 +934,143 @@ describe('app integration', () => {
     expect(response.status).toBe(200);
     expect(response.body.workspace).toEqual({
       id: 'workspace-1',
+      name: 'Personal workspace',
+      kind: 'personal',
       role: 'editor',
       isPersonal: true,
-      capabilities: { canEdit: true, canManageMembers: false },
+      capabilities: {
+        canEdit: true,
+        canManageMembers: false,
+        canRestoreSnapshots: false,
+        canImportContracts: false,
+      },
+    });
+  });
+
+  it('GET /api/v1/workspaces lista workspaces accesibles con identidad para la UI', async () => {
+    const actorIdentity = buildActorIdentity('owner');
+    prismaMock.externalIdentity.findUnique.mockResolvedValueOnce({
+      ...actorIdentity,
+      user: {
+        ...actorIdentity.user,
+        memberships: [
+          { workspaceId: 'workspace-1', role: 'owner' },
+          { workspaceId: 'workspace-2', role: 'editor' },
+        ],
+      },
+    });
+    prismaMock.workspaceMembership.findMany.mockResolvedValueOnce([
+      {
+        workspaceId: 'workspace-1',
+        role: 'owner',
+        workspace: {
+          id: 'workspace-1',
+          name: 'Personal workspace',
+          kind: 'personal',
+        },
+      },
+      {
+        workspaceId: 'workspace-2',
+        role: 'editor',
+        workspace: {
+          id: 'workspace-2',
+          name: 'Equipo Plataforma',
+          kind: 'team',
+        },
+      },
+    ]);
+
+    const response = await request(app).get('/api/v1/workspaces').set(authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      items: [
+        {
+          id: 'workspace-1',
+          name: 'Personal workspace',
+          kind: 'personal',
+          role: 'owner',
+          isPersonal: true,
+          capabilities: {
+            canEdit: true,
+            canManageMembers: true,
+            canRestoreSnapshots: true,
+            canImportContracts: true,
+          },
+        },
+        {
+          id: 'workspace-2',
+          name: 'Equipo Plataforma',
+          kind: 'team',
+          role: 'editor',
+          isPersonal: false,
+          capabilities: {
+            canEdit: true,
+            canManageMembers: false,
+            canRestoreSnapshots: false,
+            canImportContracts: false,
+          },
+        },
+      ],
+    });
+  });
+
+  it('POST /api/v1/workspaces crea team workspace y membresía owner para el actor', async () => {
+    const tx = {
+      workspace: {
+        create: vi.fn().mockResolvedValue({
+          id: 'workspace-2',
+          name: 'Equipo Plataforma',
+          kind: 'team',
+        }),
+      },
+      workspaceMembership: {
+        create: vi.fn().mockResolvedValue({
+          workspaceId: 'workspace-2',
+          userId: 'user-1',
+          role: 'owner',
+        }),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementationOnce(async (callback) => callback(tx));
+
+    const response = await request(app)
+      .post('/api/v1/workspaces')
+      .set(authHeaders())
+      .send({ name: 'Equipo Plataforma' });
+
+    expect(response.status).toBe(201);
+    expect(tx.workspace.create).toHaveBeenCalledWith({
+      data: {
+        name: 'Equipo Plataforma',
+        kind: 'team',
+      },
+      select: {
+        id: true,
+        name: true,
+        kind: true,
+      },
+    });
+    expect(tx.workspaceMembership.create).toHaveBeenCalledWith({
+      data: {
+        workspaceId: 'workspace-2',
+        userId: 'user-1',
+        role: 'owner',
+      },
+    });
+    expect(response.body).toEqual({
+      id: 'workspace-2',
+      name: 'Equipo Plataforma',
+      kind: 'team',
+      role: 'owner',
+      isPersonal: false,
+      capabilities: {
+        canEdit: true,
+        canManageMembers: true,
+        canRestoreSnapshots: true,
+        canImportContracts: true,
+      },
     });
   });
 
@@ -734,6 +1230,7 @@ describe('app integration', () => {
       prismaMock.project.findUnique.mockResolvedValueOnce({
         id: 'p1',
         workspaceId: 'workspace-1',
+        workspace: { id: 'workspace-1', name: 'Personal workspace', kind: 'personal' },
         name: 'Proyecto',
         slug: 'proyecto',
         description: 'Demo',
@@ -828,9 +1325,16 @@ describe('app integration', () => {
         mockUrl: 'https://mock.example.com/public-base/proyecto',
         workspace: {
           id: 'workspace-1',
+          name: 'Personal workspace',
+          kind: 'personal',
           role: 'owner',
           isPersonal: true,
-          capabilities: { canEdit: true, canManageMembers: true },
+          capabilities: {
+            canEdit: true,
+            canManageMembers: true,
+            canRestoreSnapshots: true,
+            canImportContracts: true,
+          },
         },
         updatedAt: '2026-04-08T10:00:00.000Z',
         status: 'attention',
@@ -1009,6 +1513,380 @@ describe('app integration', () => {
     expect(prismaMock.workspaceMembership.delete).not.toHaveBeenCalled();
   });
 
+  it('permite a owner actualizar el rol de un miembro existente', async () => {
+    prismaMock.workspaceMembership.findUnique.mockResolvedValueOnce({
+      userId: 'user-2',
+      role: 'viewer',
+      createdAt: new Date('2026-04-08T09:05:00.000Z'),
+      user: { email: 'viewer@example.com', displayName: 'Viewer User' },
+    });
+    prismaMock.workspaceMembership.update.mockResolvedValueOnce({
+      userId: 'user-2',
+      role: 'editor',
+      createdAt: new Date('2026-04-08T09:05:00.000Z'),
+      user: { email: 'viewer@example.com', displayName: 'Viewer User' },
+    });
+
+    const response = await request(app)
+      .patch('/api/v1/workspaces/workspace-1/members/user-2')
+      .set(authHeaders())
+      .send({ role: 'editor' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      userId: 'user-2',
+      email: 'viewer@example.com',
+      displayName: 'Viewer User',
+      role: 'editor',
+      createdAt: '2026-04-08T09:05:00.000Z',
+    });
+    expect(prismaMock.workspaceMembership.update).toHaveBeenCalledWith({
+      where: {
+        workspaceId_userId: {
+          workspaceId: 'workspace-1',
+          userId: 'user-2',
+        },
+      },
+      data: { role: 'editor' },
+      select: {
+        userId: true,
+        role: true,
+        createdAt: true,
+        user: {
+          select: {
+            email: true,
+            displayName: true,
+          },
+        },
+      },
+    });
+  });
+
+  it('devuelve 404 al actualizar una membresía inexistente', async () => {
+    prismaMock.workspaceMembership.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(app)
+      .patch('/api/v1/workspaces/workspace-1/members/user-404')
+      .set(authHeaders())
+      .send({ role: 'editor' });
+
+    expect(response.status).toBe(404);
+    expect(response.body.code).toBe('WORKSPACE_MEMBER_NOT_FOUND');
+    expect(prismaMock.workspaceMembership.update).not.toHaveBeenCalled();
+  });
+
+  it('bloquea degradar al último owner del workspace', async () => {
+    prismaMock.workspaceMembership.findUnique.mockResolvedValueOnce({
+      userId: 'user-2',
+      role: 'owner',
+      createdAt: new Date('2026-04-08T09:05:00.000Z'),
+      user: { email: 'owner2@example.com', displayName: 'Second Owner' },
+    });
+    prismaMock.workspaceMembership.count.mockResolvedValueOnce(1);
+
+    const response = await request(app)
+      .patch('/api/v1/workspaces/workspace-1/members/user-2')
+      .set(authHeaders())
+      .send({ role: 'editor' });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('WORKSPACE_LAST_OWNER_REQUIRED');
+    expect(prismaMock.workspaceMembership.update).not.toHaveBeenCalled();
+  });
+
+  it('bloquea auto-degradación del owner autenticado', async () => {
+    const response = await request(app)
+      .patch('/api/v1/workspaces/workspace-1/members/user-1')
+      .set(authHeaders())
+      .send({ role: 'editor' });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('WORKSPACE_MEMBER_SELF_DEMOTION_BLOCKED');
+    expect(prismaMock.workspaceMembership.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.workspaceMembership.update).not.toHaveBeenCalled();
+  });
+
+  it('permite a owner crear, listar y revocar invitaciones pendientes', async () => {
+    prismaMock.workspaceInvitation.create.mockResolvedValueOnce({
+      id: 'invite-1',
+      workspaceId: 'workspace-1',
+      email: 'viewer@example.com',
+      role: 'viewer',
+      status: 'pending',
+      createdAt: new Date('2026-04-08T09:10:00.000Z'),
+      workspace: { id: 'workspace-1', name: 'Personal workspace' },
+    });
+    prismaMock.workspaceInvitation.findMany.mockResolvedValueOnce([
+      {
+        id: 'invite-1',
+        workspaceId: 'workspace-1',
+        email: 'viewer@example.com',
+        role: 'viewer',
+        status: 'pending',
+        createdAt: new Date('2026-04-08T09:10:00.000Z'),
+        workspace: { id: 'workspace-1', name: 'Personal workspace' },
+      },
+    ]);
+    prismaMock.workspaceInvitation.findUnique.mockResolvedValueOnce({
+      id: 'invite-1',
+      workspaceId: 'workspace-1',
+      status: 'pending',
+    });
+    prismaMock.workspaceInvitation.update.mockResolvedValueOnce({
+      id: 'invite-1',
+      workspaceId: 'workspace-1',
+      email: 'viewer@example.com',
+      role: 'viewer',
+      status: 'revoked',
+      createdAt: new Date('2026-04-08T09:10:00.000Z'),
+      workspace: { id: 'workspace-1', name: 'Personal workspace' },
+    });
+
+    const createResponse = await request(app)
+      .post('/api/v1/workspaces/workspace-1/invitations')
+      .set(authHeaders())
+      .send({ email: 'viewer@example.com', role: 'viewer' });
+
+    expect(createResponse.status).toBe(201);
+    expect(createResponse.body).toEqual({
+      id: 'invite-1',
+      workspaceId: 'workspace-1',
+      workspaceName: 'Personal workspace',
+      email: 'viewer@example.com',
+      role: 'viewer',
+      status: 'pending',
+      createdAt: '2026-04-08T09:10:00.000Z',
+    });
+
+    const listResponse = await request(app)
+      .get('/api/v1/workspaces/workspace-1/invitations')
+      .set(authHeaders());
+
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.body.items).toEqual([
+      {
+        id: 'invite-1',
+        workspaceId: 'workspace-1',
+        workspaceName: 'Personal workspace',
+        email: 'viewer@example.com',
+        role: 'viewer',
+        status: 'pending',
+        createdAt: '2026-04-08T09:10:00.000Z',
+      },
+    ]);
+
+    const revokeResponse = await request(app)
+      .delete('/api/v1/workspaces/workspace-1/invitations/invite-1')
+      .set(authHeaders());
+
+    expect(revokeResponse.status).toBe(204);
+    expect(prismaMock.workspaceInvitation.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'invite-1' },
+        data: expect.objectContaining({
+          status: 'revoked',
+        }),
+      })
+    );
+  });
+
+  it('permite crear invitaciones con rol editor', async () => {
+    prismaMock.workspaceInvitation.create.mockResolvedValueOnce({
+      id: 'invite-editor-1',
+      workspaceId: 'workspace-1',
+      email: 'editor@example.com',
+      role: 'editor',
+      status: 'pending',
+      createdAt: new Date('2026-04-08T09:11:00.000Z'),
+      workspace: { id: 'workspace-1', name: 'Personal workspace' },
+    });
+
+    const response = await request(app)
+      .post('/api/v1/workspaces/workspace-1/invitations')
+      .set(authHeaders())
+      .send({ email: 'editor@example.com', role: 'editor' });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      id: 'invite-editor-1',
+      workspaceId: 'workspace-1',
+      workspaceName: 'Personal workspace',
+      email: 'editor@example.com',
+      role: 'editor',
+      status: 'pending',
+      createdAt: '2026-04-08T09:11:00.000Z',
+    });
+    expect(prismaMock.workspaceInvitation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          role: 'editor',
+        }),
+      })
+    );
+  });
+
+  it('rechaza invitaciones pendientes duplicadas para el mismo workspace y email', async () => {
+    prismaMock.workspaceInvitation.findFirst.mockResolvedValueOnce({ id: 'invite-1' });
+
+    const response = await request(app)
+      .post('/api/v1/workspaces/workspace-1/invitations')
+      .set(authHeaders())
+      .send({ email: 'viewer@example.com', role: 'viewer' });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('WORKSPACE_INVITATION_ALREADY_PENDING');
+    expect(prismaMock.workspaceInvitation.create).not.toHaveBeenCalled();
+  });
+
+  it('rechaza crear invitaciones con rol owner', async () => {
+    const response = await request(app)
+      .post('/api/v1/workspaces/workspace-1/invitations')
+      .set(authHeaders())
+      .send({ email: 'owner-invite@example.com', role: 'owner' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({
+      error: 'Validation Error',
+    });
+    expect(response.body.details).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: 'role',
+        }),
+      ])
+    );
+    expect(prismaMock.workspaceInvitation.create).not.toHaveBeenCalled();
+  });
+
+  it('lista las invitaciones pendientes del actor autenticado por email', async () => {
+    prismaMock.workspaceInvitation.findMany.mockResolvedValueOnce([
+      {
+        id: 'invite-1',
+        workspaceId: 'workspace-2',
+        email: 'owner@example.com',
+        role: 'editor',
+        status: 'pending',
+        createdAt: new Date('2026-04-08T09:20:00.000Z'),
+        workspace: { id: 'workspace-2', name: 'Equipo Plataforma' },
+      },
+    ]);
+
+    const response = await request(app)
+      .get('/api/v1/workspace-invitations/pending')
+      .set(authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toEqual([
+      {
+        id: 'invite-1',
+        workspaceId: 'workspace-2',
+        workspaceName: 'Equipo Plataforma',
+        email: 'owner@example.com',
+        role: 'editor',
+        status: 'pending',
+        createdAt: '2026-04-08T09:20:00.000Z',
+      },
+    ]);
+    expect(prismaMock.workspaceInvitation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          email: 'owner@example.com',
+          status: 'pending',
+        }),
+      })
+    );
+  });
+
+  it('acepta invitaciones pendientes en-app creando la membresía transaccionalmente', async () => {
+    prismaMock.workspaceInvitation.findUnique.mockResolvedValueOnce({
+      id: 'invite-1',
+      workspaceId: 'workspace-2',
+      email: 'owner@example.com',
+      role: 'editor',
+      status: 'pending',
+    });
+    prismaMock.workspaceMembership.findUnique.mockResolvedValueOnce(null);
+
+    const response = await request(app)
+      .post('/api/v1/workspace-invitations/invite-1/accept')
+      .set(authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ accepted: true });
+    expect(prismaMock.$transaction).toHaveBeenCalled();
+    expect(prismaMock.workspaceMembership.create).toHaveBeenCalledWith({
+      data: {
+        workspaceId: 'workspace-2',
+        userId: 'user-1',
+        role: 'editor',
+      },
+    });
+    expect(prismaMock.workspaceInvitation.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'invite-1' },
+        data: expect.objectContaining({
+          status: 'accepted',
+          acceptedByUserId: 'user-1',
+        }),
+      })
+    );
+  });
+
+  it('bloquea aceptar invitaciones si el email autenticado no coincide', async () => {
+    prismaMock.workspaceInvitation.findUnique.mockResolvedValueOnce({
+      id: 'invite-1',
+      workspaceId: 'workspace-2',
+      email: 'someone@example.com',
+      role: 'editor',
+      status: 'pending',
+    });
+
+    const response = await request(app)
+      .post('/api/v1/workspace-invitations/invite-1/accept')
+      .set(authHeaders());
+
+    expect(response.status).toBe(403);
+    expect(response.body.code).toBe('WORKSPACE_INVITATION_EMAIL_MISMATCH');
+    expect(prismaMock.workspaceMembership.create).not.toHaveBeenCalled();
+  });
+
+  it('bloquea aceptar invitaciones ya revocadas', async () => {
+    prismaMock.workspaceInvitation.findUnique.mockResolvedValueOnce({
+      id: 'invite-1',
+      workspaceId: 'workspace-2',
+      email: 'owner@example.com',
+      role: 'editor',
+      status: 'revoked',
+    });
+
+    const response = await request(app)
+      .post('/api/v1/workspace-invitations/invite-1/accept')
+      .set(authHeaders());
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('WORKSPACE_INVITATION_ALREADY_REVOKED');
+    expect(prismaMock.workspaceMembership.create).not.toHaveBeenCalled();
+  });
+
+  it('bloquea aceptar invitaciones cuando la membresía ya existe', async () => {
+    prismaMock.workspaceInvitation.findUnique.mockResolvedValueOnce({
+      id: 'invite-1',
+      workspaceId: 'workspace-2',
+      email: 'owner@example.com',
+      role: 'editor',
+      status: 'pending',
+    });
+    prismaMock.workspaceMembership.findUnique.mockResolvedValueOnce({ userId: 'user-1' });
+
+    const response = await request(app)
+      .post('/api/v1/workspace-invitations/invite-1/accept')
+      .set(authHeaders());
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe('WORKSPACE_MEMBER_ALREADY_EXISTS');
+    expect(prismaMock.workspaceInvitation.update).not.toHaveBeenCalled();
+  });
+
   it('GET /api/v1/projects/:projectId/dashboard-summary responde 404 cuando falta el proyecto', async () => {
     prismaMock.project.findUnique.mockResolvedValueOnce(null);
 
@@ -1024,6 +1902,7 @@ describe('app integration', () => {
     prismaMock.project.findUnique.mockResolvedValueOnce({
       id: 'p1',
       workspaceId: 'workspace-1',
+      workspace: { id: 'workspace-1', name: 'Personal workspace', kind: 'personal' },
       name: 'Proyecto vacío',
       slug: 'proyecto-vacio',
       description: '',

--- a/apps/backend/src/__tests__/project-contracts.integration.test.ts
+++ b/apps/backend/src/__tests__/project-contracts.integration.test.ts
@@ -209,7 +209,7 @@ describe('project contracts integration', () => {
     );
   });
 
-  it('rejects import for read-only viewers and writes an import audit event for mutators', async () => {
+  it('rejects import for viewers and editors, then writes an import audit event for owners', async () => {
     prismaMock.externalIdentity.findUnique.mockResolvedValue(buildActorIdentity('viewer'));
 
     const denied = await request(app)
@@ -239,8 +239,45 @@ describe('project contracts integration', () => {
       );
 
     expect(denied.status).toBe(403);
+    expect(denied.body).toEqual({
+      error: 'You do not have permission to import OpenAPI contracts',
+      code: 'WORKSPACE_CONTRACT_IMPORT_DENIED',
+    });
 
     prismaMock.externalIdentity.findUnique.mockResolvedValue(buildActorIdentity('editor'));
+    const editorDenied = await request(app)
+      .post('/api/v1/projects/project-1/openapi/import')
+      .set(authHeaders())
+      .attach(
+        'file',
+        Buffer.from(
+          JSON.stringify({
+            openapi: '3.0.3',
+            info: { title: 'Users API', version: '1.0.0' },
+            paths: {
+              '/accounts': {
+                post: {
+                  responses: {
+                    '201': {
+                      description: 'created',
+                      content: { 'application/json': { example: { ok: true } } },
+                    },
+                  },
+                },
+              },
+            },
+          })
+        ),
+        'contract.json'
+      );
+
+    expect(editorDenied.status).toBe(403);
+    expect(editorDenied.body).toEqual({
+      error: 'You do not have permission to import OpenAPI contracts',
+      code: 'WORKSPACE_CONTRACT_IMPORT_DENIED',
+    });
+
+    prismaMock.externalIdentity.findUnique.mockResolvedValue(buildActorIdentity('owner'));
     const allowed = await request(app)
       .post('/api/v1/projects/project-1/openapi/import')
       .set(authHeaders())

--- a/apps/backend/src/__tests__/project-snapshots.integration.test.ts
+++ b/apps/backend/src/__tests__/project-snapshots.integration.test.ts
@@ -29,9 +29,11 @@ const prismaMock = {
   },
   globalConfig: {
     upsert: vi.fn(),
+    findUnique: vi.fn(),
   },
   endpoint: {
     findMany: vi.fn(),
+    findUnique: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
     deleteMany: vi.fn(),
@@ -121,10 +123,30 @@ describe('project snapshots integration', () => {
     vi.clearAllMocks();
     prismaMock.externalIdentity.findUnique.mockResolvedValue(buildActorIdentity());
     prismaMock.project.findUnique.mockImplementation(
-      async ({ where }: { where: { id: string } }) => ({
-        id: where.id,
-        workspaceId: 'workspace-1',
-      })
+      async ({
+        where,
+        include,
+      }: {
+        where: { id: string };
+        include?: { globalConfig?: boolean; endpoints?: unknown };
+      }) => {
+        if (include) {
+          return {
+            id: where.id,
+            workspaceId: 'workspace-1',
+            slug: 'users-api',
+            name: 'Live Users API',
+            description: 'Live description',
+            globalConfig: null,
+            endpoints: [],
+          };
+        }
+
+        return {
+          id: where.id,
+          workspaceId: 'workspace-1',
+        };
+      }
     );
     prismaMock.user.findUnique.mockResolvedValue({
       email: 'owner@example.com',
@@ -200,7 +222,7 @@ describe('project snapshots integration', () => {
           resourceType: 'snapshot',
           resourceId: 'snapshot-1',
           action: 'created',
-          summary: 'Created snapshot Before edits',
+          summary: 'Created revision Before edits',
         }),
       })
     );
@@ -227,6 +249,19 @@ describe('project snapshots integration', () => {
         createdByUserId: 'user-1',
         createdByEmail: 'owner@example.com',
         createdByDisplayName: 'Owner User',
+        payload: {
+          project: {
+            id: 'project-1',
+            slug: 'users-api',
+            name: 'Users API',
+            description: 'Project snapshot',
+          },
+          globalConfig: { projectId: 'project-1', scope: 'unset' },
+          endpoints: [
+            { method: 'GET', path: '/users', scenarios: [{ name: 'ok' }] },
+            { method: 'POST', path: '/users', scenarios: [] },
+          ],
+        },
         createdAt: new Date('2026-04-17T09:00:00.000Z'),
       },
       {
@@ -237,6 +272,16 @@ describe('project snapshots integration', () => {
         createdByUserId: 'user-2',
         createdByEmail: 'other@example.com',
         createdByDisplayName: 'Other User',
+        payload: {
+          project: {
+            id: 'project-2',
+            slug: 'foreign-api',
+            name: 'Foreign API',
+            description: '',
+          },
+          globalConfig: { projectId: 'project-2', scope: 'all' },
+          endpoints: [],
+        },
         createdAt: new Date('2026-04-17T11:00:00.000Z'),
       },
       {
@@ -247,6 +292,16 @@ describe('project snapshots integration', () => {
         createdByUserId: 'user-1',
         createdByEmail: 'owner@example.com',
         createdByDisplayName: 'Owner User',
+        payload: {
+          project: {
+            id: 'project-1',
+            slug: 'users-api',
+            name: 'Users API',
+            description: 'Project snapshot',
+          },
+          globalConfig: { projectId: 'project-1', scope: 'all' },
+          endpoints: [{ method: 'GET', path: '/health', scenarios: [] }],
+        },
         createdAt: new Date('2026-04-17T10:00:00.000Z'),
       },
     ];
@@ -284,6 +339,22 @@ describe('project snapshots integration', () => {
       'snapshot-newest',
       'snapshot-older',
     ]);
+    expect(response.body.items[0]?.revision).toEqual({
+      endpointCount: 1,
+      scenarioCount: 0,
+      globalScope: 'all',
+      projectSlug: 'users-api',
+      projectName: 'Users API',
+      isLegacySnapshot: false,
+    });
+    expect(response.body.items[1]?.revision).toEqual({
+      endpointCount: 2,
+      scenarioCount: 1,
+      globalScope: 'unset',
+      projectSlug: 'users-api',
+      projectName: 'Users API',
+      isLegacySnapshot: false,
+    });
     expect(
       response.body.items.every((item: { projectId: string }) => item.projectId === 'project-1')
     ).toBe(true);
@@ -337,6 +408,14 @@ describe('project snapshots integration', () => {
       id: 'snapshot-1',
       projectId: 'project-1',
       name: 'Before edits',
+      revision: {
+        endpointCount: 0,
+        scenarioCount: 0,
+        globalScope: 'all',
+        projectSlug: 'users-api',
+        projectName: 'Users API',
+        isLegacySnapshot: false,
+      },
       createdBy: {
         userId: 'user-1',
         email: 'owner@example.com',
@@ -437,6 +516,23 @@ describe('project snapshots integration', () => {
     expect(prismaMock.auditEvent.create).not.toHaveBeenCalled();
   });
 
+  it('rejects snapshot restore for editors even when normal workspace edits are still allowed', async () => {
+    prismaMock.externalIdentity.findUnique.mockResolvedValue(buildActorIdentity('editor'));
+
+    const restoreResponse = await request(app)
+      .post('/api/v1/projects/project-1/snapshots/snapshot-1/restore')
+      .set(authHeaders())
+      .send({});
+
+    expect(restoreResponse.status).toBe(403);
+    expect(restoreResponse.body).toEqual({
+      error: 'You do not have permission to restore project snapshots',
+      code: 'WORKSPACE_SNAPSHOT_RESTORE_DENIED',
+    });
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+    expect(prismaMock.auditEvent.create).not.toHaveBeenCalled();
+  });
+
   it('blocks snapshot list and detail reads for non-members', async () => {
     prismaMock.externalIdentity.findUnique.mockResolvedValue(
       buildActorIdentityForWorkspace([{ workspaceId: 'workspace-2', role: 'viewer' }])
@@ -464,6 +560,40 @@ describe('project snapshots integration', () => {
   });
 
   it('restores a snapshot through one transaction and emits a single restore audit event', async () => {
+    prismaMock.project.findUnique.mockImplementation(
+      async ({
+        where,
+        include,
+      }: {
+        where: { id: string };
+        include?: { globalConfig?: boolean; endpoints?: unknown };
+      }) => {
+        if (include) {
+          return {
+            id: where.id,
+            workspaceId: 'workspace-1',
+            slug: 'users-api',
+            name: 'Live Users API',
+            description: 'Live description',
+            globalConfig: null,
+            endpoints: [
+              {
+                id: 'endpoint-old',
+                method: 'DELETE',
+                path: '/users/:id',
+                description: 'Delete user',
+                statusCode: 204,
+                responseBody: null,
+                endpointConfig: null,
+                scenarios: [],
+              },
+            ],
+          };
+        }
+
+        return { id: where.id, workspaceId: 'workspace-1' };
+      }
+    );
     prismaMock.projectSnapshot.findFirst.mockResolvedValue({
       id: 'snapshot-1',
       projectId: 'project-1',
@@ -528,6 +658,7 @@ describe('project snapshots integration', () => {
       },
       endpoint: {
         findMany: vi.fn(async () => [{ id: 'endpoint-old', method: 'DELETE', path: '/users/:id' }]),
+        findUnique: vi.fn(),
         create: vi.fn(async () => ({ id: 'endpoint-1' })),
         update: vi.fn(),
         deleteMany: vi.fn(async () => ({ count: 1 })),
@@ -555,6 +686,12 @@ describe('project snapshots integration', () => {
       .send({});
 
     expect(response.status).toBe(200);
+    expect(tx.globalConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ scope: 'all' }),
+        create: expect.objectContaining({ scope: 'all' }),
+      })
+    );
     expect(tx.endpoint.deleteMany).toHaveBeenCalledWith({
       where: { id: { in: ['endpoint-old'] } },
     });
@@ -565,7 +702,7 @@ describe('project snapshots integration', () => {
           resourceType: 'snapshot',
           resourceId: 'snapshot-1',
           action: 'restored',
-          summary: 'Restored snapshot Before imports',
+          summary: 'Restored revision Before imports',
         }),
       })
     );
@@ -637,6 +774,7 @@ describe('project snapshots integration', () => {
       },
       endpoint: {
         findMany: vi.fn(async () => []),
+        findUnique: vi.fn(),
         create: vi.fn(async () => {
           throw new Error('restore failed');
         }),
@@ -812,11 +950,13 @@ describe('project snapshots integration', () => {
               workingState.globalConfig = { ...update };
               return workingState.globalConfig;
             }),
+            findUnique: vi.fn(),
           },
           endpoint: {
             findMany: vi.fn(async () =>
               workingState.endpoints.map(({ id, method, path }) => ({ id, method, path }))
             ),
+            findUnique: vi.fn(),
             create: vi.fn(
               async ({
                 data,
@@ -895,5 +1035,259 @@ describe('project snapshots integration', () => {
       },
     ]);
     expect(liveState.auditEvents).toEqual([]);
+  });
+
+  it('returns a restore preview diff before mutating live state', async () => {
+    prismaMock.project.findUnique.mockImplementation(
+      async ({
+        where,
+        include,
+      }: {
+        where: { id: string };
+        include?: { globalConfig?: boolean; endpoints?: unknown };
+      }) => {
+        if (where.id !== 'project-1') return null;
+        if (include) {
+          return {
+            id: 'project-1',
+            workspaceId: 'workspace-1',
+            slug: 'users-api',
+            name: 'Live Users API',
+            description: 'Live description',
+            globalConfig: {
+              projectId: 'project-1',
+              latencyEnabled: false,
+              latencyMinMs: 0,
+              latencyMaxMs: 1000,
+              latencyMode: 'fixed',
+              errorSimulationEnabled: false,
+              errorSimulationRate: 0,
+              errorSimulationCodes: [500],
+              rateLimitingEnabled: false,
+              rateLimitingRpm: 60,
+              loggingLevel: 'basic',
+              scope: 'all',
+            },
+            endpoints: [
+              {
+                id: 'endpoint-1',
+                method: 'GET',
+                path: '/users',
+                description: 'Live list users',
+                statusCode: 200,
+                responseBody: [],
+                endpointConfig: {
+                  latencyMode: 'fixed',
+                  fixedDelayMs: 0,
+                  minDelayMs: 0,
+                  maxDelayMs: 500,
+                  errorRate: 0,
+                  useScenarioWeights: true,
+                },
+                scenarios: [],
+              },
+              {
+                id: 'endpoint-2',
+                method: 'DELETE',
+                path: '/users/:id',
+                description: 'Delete user',
+                statusCode: 204,
+                responseBody: null,
+                endpointConfig: {
+                  latencyMode: 'fixed',
+                  fixedDelayMs: 0,
+                  minDelayMs: 0,
+                  maxDelayMs: 500,
+                  errorRate: 0,
+                  useScenarioWeights: true,
+                },
+                scenarios: [],
+              },
+            ],
+          };
+        }
+
+        return {
+          id: 'project-1',
+          workspaceId: 'workspace-1',
+        };
+      }
+    );
+    prismaMock.projectSnapshot.findFirst.mockResolvedValue({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before imports',
+      description: '',
+      createdByUserId: 'user-1',
+      createdByEmail: 'owner@example.com',
+      createdByDisplayName: 'Owner User',
+      payload: {
+        project: {
+          id: 'project-1',
+          slug: 'users-api',
+          name: 'Snapshot Users API',
+          description: 'Snapshot description',
+        },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: true,
+          latencyMinMs: 10,
+          latencyMaxMs: 20,
+          latencyMode: 'range',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 60,
+          loggingLevel: 'full',
+          scope: 'unset',
+        },
+        endpoints: [
+          {
+            method: 'GET',
+            path: '/users',
+            description: 'Snapshot list users',
+            statusCode: 200,
+            responseBody: [{ id: 1 }],
+            endpointConfig: {
+              latencyMode: 'fixed',
+              fixedDelayMs: 0,
+              minDelayMs: 0,
+              maxDelayMs: 500,
+              errorRate: 0,
+              useScenarioWeights: true,
+            },
+            scenarios: [],
+          },
+          {
+            method: 'POST',
+            path: '/users',
+            description: 'Create user',
+            statusCode: 201,
+            responseBody: { ok: true },
+            endpointConfig: {
+              latencyMode: 'fixed',
+              fixedDelayMs: 0,
+              minDelayMs: 0,
+              maxDelayMs: 500,
+              errorRate: 0,
+              useScenarioWeights: true,
+            },
+            scenarios: [],
+          },
+        ],
+      },
+      createdAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+    const response = await request(app)
+      .get('/api/v1/projects/project-1/snapshots/snapshot-1/restore-preview')
+      .set(authHeaders());
+
+    expect(response.status).toBe(200);
+    expect(response.body.project.name).toEqual({
+      current: 'Live Users API',
+      snapshot: 'Snapshot Users API',
+      changed: true,
+    });
+    expect(response.body.revision).toEqual({
+      endpointCount: 2,
+      scenarioCount: 0,
+      globalScope: 'unset',
+      projectSlug: 'users-api',
+      projectName: 'Snapshot Users API',
+      isLegacySnapshot: false,
+    });
+    expect(response.body.globalConfig.changed).toBe(true);
+    expect(response.body.endpoints.create.map((entry: { key: string }) => entry.key)).toEqual([
+      'POST /users',
+    ]);
+    expect(response.body.endpoints.update.map((entry: { key: string }) => entry.key)).toEqual([
+      'GET /users',
+    ]);
+    expect(response.body.endpoints.delete.map((entry: { key: string }) => entry.key)).toEqual([
+      'DELETE /users/:id',
+    ]);
+    expect(response.body.counts).toEqual({
+      create: 1,
+      update: 1,
+      delete: 1,
+      keep: 0,
+      totalAfterRestore: 2,
+    });
+  });
+
+  it('restores snapshot scope from the snapshot payload instead of forcing all', async () => {
+    prismaMock.projectSnapshot.findFirst.mockResolvedValue({
+      id: 'snapshot-1',
+      projectId: 'project-1',
+      name: 'Before imports',
+      description: '',
+      createdByUserId: 'user-1',
+      createdByEmail: 'owner@example.com',
+      createdByDisplayName: 'Owner User',
+      payload: {
+        project: { id: 'project-1', slug: 'users-api', name: 'Users API', description: 'Baseline' },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: false,
+          latencyMinMs: 0,
+          latencyMaxMs: 1000,
+          latencyMode: 'fixed',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 60,
+          loggingLevel: 'basic',
+          scope: 'unset',
+        },
+        endpoints: [],
+      },
+      createdAt: new Date('2026-04-17T10:00:00.000Z'),
+    });
+
+    const tx = {
+      project: {
+        update: vi.fn(async () => ({ id: 'project-1', workspaceId: 'workspace-1' })),
+      },
+      globalConfig: {
+        upsert: vi.fn(async () => ({ projectId: 'project-1' })),
+      },
+      endpoint: {
+        findMany: vi.fn(async () => []),
+        findUnique: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        deleteMany: vi.fn(async () => ({ count: 0 })),
+      },
+      endpointConfig: {
+        upsert: vi.fn(),
+      },
+      scenario: {
+        deleteMany: vi.fn(async () => ({ count: 0 })),
+        createMany: vi.fn(async () => ({ count: 0 })),
+      },
+      user: prismaMock.user,
+      auditEvent: {
+        create: vi.fn(async () => ({ id: 'audit-restore' })),
+      },
+    };
+
+    prismaMock.$transaction.mockImplementation(
+      async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx)
+    );
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-1/snapshots/snapshot-1/restore')
+      .set(authHeaders())
+      .send({});
+
+    expect(response.status).toBe(200);
+    expect(tx.globalConfig.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({ scope: 'unset' }),
+        create: expect.objectContaining({ scope: 'unset' }),
+      })
+    );
   });
 });

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -20,6 +20,11 @@ import { projectContractsRouter } from './management/project-contracts/router.js
 import { scenariosRouter } from './management/scenarios/router.js';
 import { opsRouter } from './management/ops/router.js';
 import { workspaceMembersRouter } from './management/workspace-members/router.js';
+import {
+  workspaceInvitationsRouter,
+  workspaceScopedInvitationsRouter,
+} from './management/workspace-invitations/router.js';
+import { workspacesRouter } from './management/workspaces/router.js';
 import { mockRouter } from './mock-server/mock.router.js';
 
 export const app = express();
@@ -50,7 +55,10 @@ app.use('/api/v1/projects/:projectId/logs', logsRouter);
 app.use('/api/v1/projects/:projectId/audit-events', auditEventsRouter);
 app.use('/api/v1/projects/:projectId/snapshots', projectSnapshotsRouter);
 app.use('/api/v1/projects/:projectId/openapi', projectContractsRouter);
+app.use('/api/v1/workspaces', workspacesRouter);
 app.use('/api/v1/workspaces/:workspaceId/members', workspaceMembersRouter);
+app.use('/api/v1/workspaces/:workspaceId/invitations', workspaceScopedInvitationsRouter);
+app.use('/api/v1/workspace-invitations', workspaceInvitationsRouter);
 app.use('/mock', mockRouter);
 
 app.use(errorHandler);

--- a/apps/backend/src/auth/__tests__/identity-resolver.test.ts
+++ b/apps/backend/src/auth/__tests__/identity-resolver.test.ts
@@ -81,6 +81,8 @@ describe('resolveActorIdentity', () => {
     });
     expect(actor).toEqual({
       userId: 'user-1',
+      email: 'owner@example.com',
+      displayName: 'Owner User',
       personalWorkspaceId: 'workspace-1',
       identity: { provider: 'clerk', subject: 'user_clerk_123' },
       workspaceMemberships: [{ workspaceId: 'workspace-1', role: 'owner' }],

--- a/apps/backend/src/auth/authorization.ts
+++ b/apps/backend/src/auth/authorization.ts
@@ -2,12 +2,34 @@ import { prisma } from '../lib/prisma.js';
 import { AppError } from '../middleware/error-handler.js';
 import type {
   AuthenticatedActor,
+  WorkspaceCapabilities,
   WorkspaceAccessSummary,
   WorkspaceMembershipActor,
   WorkspaceRole,
 } from './types.js';
 
+type WorkspaceSummaryRecord = {
+  id: string;
+  name: string;
+  kind: string;
+};
+
 export type WorkspaceAccessLevel = 'read' | 'mutate' | 'owner';
+export type WorkspaceCapabilityKey = 'canRestoreSnapshots' | 'canImportContracts';
+
+const WORKSPACE_CAPABILITY_ERRORS: Record<
+  WorkspaceCapabilityKey,
+  { message: string; code: string }
+> = {
+  canRestoreSnapshots: {
+    message: 'You do not have permission to restore project snapshots',
+    code: 'WORKSPACE_SNAPSHOT_RESTORE_DENIED',
+  },
+  canImportContracts: {
+    message: 'You do not have permission to import OpenAPI contracts',
+    code: 'WORKSPACE_CONTRACT_IMPORT_DENIED',
+  },
+};
 
 function normalizeWorkspaceRole(role: string): WorkspaceRole {
   switch (role) {
@@ -42,7 +64,24 @@ export function getWorkspaceCapabilities(
   return {
     canEdit: role === 'owner' || role === 'editor',
     canManageMembers: role === 'owner',
+    canRestoreSnapshots: role === 'owner',
+    canImportContracts: role === 'owner',
   };
+}
+
+export function requireWorkspaceCapability(
+  role: WorkspaceRole,
+  capability: WorkspaceCapabilityKey,
+  capabilities: WorkspaceCapabilities = getWorkspaceCapabilities(role)
+): void {
+  if (capabilities[capability]) {
+    return;
+  }
+
+  const error = WORKSPACE_CAPABILITY_ERRORS[capability];
+  throw new AppError(403, error.message, {
+    code: error.code,
+  });
 }
 
 function assertWorkspaceLevel(role: WorkspaceRole, level: WorkspaceAccessLevel): void {
@@ -104,8 +143,44 @@ export function resolveWorkspaceAccess(
 
   return {
     id: resolvedWorkspaceId,
+    name: resolvedWorkspaceId,
+    kind: actor.personalWorkspaceId === resolvedWorkspaceId ? 'personal' : 'team',
     role: membership.role,
     isPersonal: actor.personalWorkspaceId === resolvedWorkspaceId,
+    capabilities: getWorkspaceCapabilities(membership.role),
+  };
+}
+
+export function summarizeWorkspaceAccess(
+  actor: AuthenticatedActor,
+  workspace: WorkspaceSummaryRecord | string | null,
+  level: WorkspaceAccessLevel = 'read'
+): WorkspaceAccessSummary {
+  const workspaceId = requireWorkspaceAccess(
+    actor,
+    typeof workspace === 'string' ? workspace : (workspace?.id ?? null),
+    level
+  );
+
+  const membership = getWorkspaceMembership(actor, workspaceId);
+
+  if (!membership) {
+    throw new AppError(403, 'You do not have access to this workspace', {
+      code: 'WORKSPACE_ACCESS_DENIED',
+    });
+  }
+
+  return {
+    id: workspaceId,
+    name: typeof workspace === 'object' && workspace ? workspace.name : workspaceId,
+    kind:
+      typeof workspace === 'object' && workspace?.kind === 'personal'
+        ? 'personal'
+        : actor.personalWorkspaceId === workspaceId
+          ? 'personal'
+          : 'team',
+    role: membership.role,
+    isPersonal: actor.personalWorkspaceId === workspaceId,
     capabilities: getWorkspaceCapabilities(membership.role),
   };
 }
@@ -129,6 +204,24 @@ export async function authorizeProjectAccess(
   }
 
   requireWorkspaceAccess(actor, project.workspaceId, level);
+  return project;
+}
+
+export async function authorizeProjectCapability(
+  actor: AuthenticatedActor,
+  projectId: string,
+  capability: WorkspaceCapabilityKey
+) {
+  const project = await authorizeProjectAccess(actor, projectId, 'read');
+  const membership = getWorkspaceMembership(actor, project.workspaceId ?? '');
+
+  if (!membership) {
+    throw new AppError(403, 'You do not have access to this workspace', {
+      code: 'WORKSPACE_ACCESS_DENIED',
+    });
+  }
+
+  requireWorkspaceCapability(membership.role, capability);
   return project;
 }
 

--- a/apps/backend/src/auth/identity-resolver.ts
+++ b/apps/backend/src/auth/identity-resolver.ts
@@ -7,6 +7,8 @@ type ExternalIdentityRecord = {
   userId?: string;
   user: {
     id: string;
+    email?: string | null;
+    displayName?: string | null;
     memberships: Array<{ workspaceId: string; role: string }>;
     personalWorkspace: { id: string } | null;
   };
@@ -43,6 +45,8 @@ function toActor(
 ): AuthenticatedActor {
   return {
     userId: record.user.id,
+    email: record.user.email ?? identity.email ?? null,
+    displayName: record.user.displayName ?? identity.displayName ?? null,
     personalWorkspaceId: record.user.personalWorkspace?.id ?? null,
     identity: {
       provider: identity.provider,

--- a/apps/backend/src/auth/types.ts
+++ b/apps/backend/src/auth/types.ts
@@ -18,10 +18,14 @@ export interface WorkspaceMembershipActor {
 export interface WorkspaceCapabilities {
   canEdit: boolean;
   canManageMembers: boolean;
+  canRestoreSnapshots: boolean;
+  canImportContracts: boolean;
 }
 
 export interface WorkspaceAccessSummary {
   id: string;
+  name: string;
+  kind: 'personal' | 'team';
   role: WorkspaceRole;
   isPersonal: boolean;
   capabilities: WorkspaceCapabilities;
@@ -29,6 +33,8 @@ export interface WorkspaceAccessSummary {
 
 export interface AuthenticatedActor {
   userId: string;
+  email: string | null;
+  displayName: string | null;
   personalWorkspaceId: string | null;
   identity: {
     provider: string;

--- a/apps/backend/src/management/ai/normalize-draft.ts
+++ b/apps/backend/src/management/ai/normalize-draft.ts
@@ -32,13 +32,14 @@ function normalizeScenarioType(
   type: string,
   statusCode: number,
   body: unknown
-): 'success' | 'error' | 'timeout' | 'empty' {
+): 'success' | 'error' | 'timeout' | 'empty' | 'unauthorized' {
   const normalizedType = type.trim().toLowerCase();
 
   if (normalizedType === 'success') return 'success';
   if (normalizedType === 'error') return 'error';
   if (normalizedType === 'timeout') return 'timeout';
   if (normalizedType === 'empty') return 'empty';
+  if (normalizedType === 'unauthorized') return 'unauthorized';
   if (normalizedType === 'edge-case') {
     if (statusCode === 204 || isEmptyBody(body)) {
       return 'empty';

--- a/apps/backend/src/management/ai/service.test.ts
+++ b/apps/backend/src/management/ai/service.test.ts
@@ -29,6 +29,8 @@ import {
 
 const actor: AuthenticatedActor = {
   userId: 'user-1',
+  email: 'owner@example.com',
+  displayName: 'Owner User',
   personalWorkspaceId: 'workspace-1',
   identity: {
     provider: 'clerk',

--- a/apps/backend/src/management/dashboard/schema.ts
+++ b/apps/backend/src/management/dashboard/schema.ts
@@ -2,7 +2,13 @@ import { z } from 'zod';
 
 export const dashboardProjectStatusSchema = z.enum(['empty', 'attention', 'running']);
 export const dashboardEndpointStatusSchema = z.enum(['ready', 'needs-attention']);
-export const dashboardScenarioTypeSchema = z.enum(['success', 'error', 'timeout', 'empty']);
+export const dashboardScenarioTypeSchema = z.enum([
+  'success',
+  'error',
+  'timeout',
+  'empty',
+  'unauthorized',
+]);
 export const dashboardLatencyModeSchema = z.enum(['fixed', 'range']);
 export const dashboardLoggingLevelSchema = z.enum(['basic', 'full', 'off']);
 export const dashboardScopeSchema = z.enum(['all', 'unset']);
@@ -10,9 +16,13 @@ export const workspaceRoleSchema = z.enum(['owner', 'editor', 'viewer']);
 export const workspaceCapabilitiesSchema = z.object({
   canEdit: z.boolean(),
   canManageMembers: z.boolean(),
+  canRestoreSnapshots: z.boolean(),
+  canImportContracts: z.boolean(),
 });
 export const workspaceSummarySchema = z.object({
   id: z.string(),
+  name: z.string(),
+  kind: z.enum(['personal', 'team']),
   role: workspaceRoleSchema,
   isPersonal: z.boolean(),
   capabilities: workspaceCapabilitiesSchema,

--- a/apps/backend/src/management/dashboard/service.test.ts
+++ b/apps/backend/src/management/dashboard/service.test.ts
@@ -18,7 +18,12 @@ describe('dashboard/service', () => {
           id: 'workspace-1',
           role: 'owner',
           isPersonal: true,
-          capabilities: { canEdit: true, canManageMembers: true },
+          capabilities: {
+            canEdit: true,
+            canManageMembers: true,
+            canRestoreSnapshots: true,
+            canImportContracts: true,
+          },
         },
         updatedAt: new Date('2026-04-08T10:00:00.000Z'),
         globalConfig: {
@@ -178,7 +183,12 @@ describe('dashboard/service', () => {
           id: 'workspace-1',
           role: 'viewer',
           isPersonal: false,
-          capabilities: { canEdit: false, canManageMembers: false },
+          capabilities: {
+            canEdit: false,
+            canManageMembers: false,
+            canRestoreSnapshots: false,
+            canImportContracts: false,
+          },
         },
         updatedAt: new Date('2026-04-08T10:00:00.000Z'),
         globalConfig: null,

--- a/apps/backend/src/management/dashboard/service.test.ts
+++ b/apps/backend/src/management/dashboard/service.test.ts
@@ -16,6 +16,8 @@ describe('dashboard/service', () => {
         slug: 'users-api',
         workspace: {
           id: 'workspace-1',
+          name: 'Personal',
+          kind: 'personal',
           role: 'owner',
           isPersonal: true,
           capabilities: {
@@ -181,6 +183,8 @@ describe('dashboard/service', () => {
         slug: 'empty-api',
         workspace: {
           id: 'workspace-1',
+          name: 'Team',
+          kind: 'team',
           role: 'viewer',
           isPersonal: false,
           capabilities: {

--- a/apps/backend/src/management/dashboard/service.ts
+++ b/apps/backend/src/management/dashboard/service.ts
@@ -1,4 +1,4 @@
-import { requireWorkspaceAccess, resolveWorkspaceAccess } from '../../auth/authorization.js';
+import { requireWorkspaceAccess, summarizeWorkspaceAccess } from '../../auth/authorization.js';
 import { env } from '../../config/env.js';
 import { DEFAULT_GLOBAL_CONFIG_VALUES } from '../global-config/defaults.js';
 import type { AuthenticatedActor } from '../../auth/types.js';
@@ -145,6 +145,13 @@ export async function getProjectDashboardSummary(
     where: { id: projectId },
     include: {
       globalConfig: true,
+      workspace: {
+        select: {
+          id: true,
+          name: true,
+          kind: true,
+        },
+      },
     },
   });
 
@@ -262,7 +269,7 @@ export async function getProjectDashboardSummary(
   return buildDashboardSummary({
     project: {
       ...project,
-      workspace: resolveWorkspaceAccess(actor, project.workspaceId),
+      workspace: summarizeWorkspaceAccess(actor, project.workspace ?? project.workspaceId),
       globalConfig: normalizeProjectGlobalConfig(project.globalConfig),
     },
     endpointRows: endpointRows.map((endpoint) => ({

--- a/apps/backend/src/management/endpoint-config/service.test.ts
+++ b/apps/backend/src/management/endpoint-config/service.test.ts
@@ -28,6 +28,8 @@ import { upsertEndpointConfig } from './service.js';
 
 const actor: AuthenticatedActor = {
   userId: 'user-1',
+  email: 'owner@example.com',
+  displayName: 'Owner User',
   personalWorkspaceId: 'workspace-1',
   identity: {
     provider: 'clerk',

--- a/apps/backend/src/management/endpoints/service.test.ts
+++ b/apps/backend/src/management/endpoints/service.test.ts
@@ -28,6 +28,8 @@ import { updateEndpoint } from './service.js';
 
 const actor: AuthenticatedActor = {
   userId: 'user-1',
+  email: 'owner@example.com',
+  displayName: 'Owner User',
   personalWorkspaceId: 'workspace-1',
   identity: {
     provider: 'clerk',

--- a/apps/backend/src/management/global-config/service.test.ts
+++ b/apps/backend/src/management/global-config/service.test.ts
@@ -14,11 +14,15 @@ describe('global-config/service', () => {
         slug: 'users-api',
         workspace: {
           id: 'workspace-1',
+          name: 'Personal',
+          kind: 'personal',
           role: 'owner',
           isPersonal: true,
           capabilities: {
             canEdit: true,
             canManageMembers: true,
+            canRestoreSnapshots: true,
+            canImportContracts: true,
           },
         },
         updatedAt: new Date('2026-04-08T10:00:00.000Z'),

--- a/apps/backend/src/management/project-contracts/service.ts
+++ b/apps/backend/src/management/project-contracts/service.ts
@@ -1,7 +1,7 @@
 import SwaggerParser from '@apidevtools/swagger-parser';
 import type { OpenAPIV3 } from 'openapi-types';
 import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
-import { authorizeProjectAccess } from '../../auth/authorization.js';
+import { authorizeProjectAccess, authorizeProjectCapability } from '../../auth/authorization.js';
 import type { AuthenticatedActor } from '../../auth/types.js';
 import { prisma } from '../../lib/prisma.js';
 import { toPrismaJson } from '../../lib/prisma-json.js';
@@ -214,7 +214,10 @@ function normalizeScenarioList(
           ? item['name'].trim()
           : `Scenario ${index + 1}`,
       type:
-        item['type'] === 'error' || item['type'] === 'timeout' || item['type'] === 'empty'
+        item['type'] === 'error' ||
+        item['type'] === 'timeout' ||
+        item['type'] === 'empty' ||
+        item['type'] === 'unauthorized'
           ? item['type']
           : 'success',
       statusCode: typeof item['statusCode'] === 'number' ? item['statusCode'] : fallbackStatus,
@@ -731,7 +734,7 @@ export async function importProjectContract(
   sourceText: string,
   sourceName?: string
 ): Promise<ProjectContractImportResult> {
-  const access = await authorizeProjectAccess(actor, projectId, 'mutate');
+  const access = await authorizeProjectCapability(actor, projectId, 'canImportContracts');
   const parsed = await parseProjectContractDocument(sourceText, sourceName);
   const liveProject = await loadLiveProjectState(projectId);
   const plan = buildAnalysisPlan(parsed, liveProject);

--- a/apps/backend/src/management/project-snapshots/router.ts
+++ b/apps/backend/src/management/project-snapshots/router.ts
@@ -9,6 +9,7 @@ import {
 import {
   createProjectSnapshot,
   getProjectSnapshotDetail,
+  getProjectSnapshotRestorePreview,
   listProjectSnapshots,
   restoreProjectSnapshot,
 } from './service.js';
@@ -41,6 +42,16 @@ projectSnapshotsRouter.get('/:snapshotId', async (req, res, next) => {
     const actor = requireRequestActor(req);
     const { projectId, snapshotId } = snapshotParamsSchema.parse(req.params);
     res.status(200).json(await getProjectSnapshotDetail(actor, projectId, snapshotId));
+  } catch (error) {
+    next(error);
+  }
+});
+
+projectSnapshotsRouter.get('/:snapshotId/restore-preview', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { projectId, snapshotId } = snapshotParamsSchema.parse(req.params);
+    res.status(200).json(await getProjectSnapshotRestorePreview(actor, projectId, snapshotId));
   } catch (error) {
     next(error);
   }

--- a/apps/backend/src/management/project-snapshots/service.test.ts
+++ b/apps/backend/src/management/project-snapshots/service.test.ts
@@ -14,10 +14,12 @@ vi.mock('../../lib/prisma.js', () => ({
 let buildSnapshotPayload: typeof ProjectSnapshotsService.buildSnapshotPayload;
 let buildSnapshotEndpointKey: typeof ProjectSnapshotsService.buildSnapshotEndpointKey;
 let planSnapshotEndpointReconciliation: typeof ProjectSnapshotsService.planSnapshotEndpointReconciliation;
+let buildProjectSnapshotRestorePreview: typeof ProjectSnapshotsService.buildProjectSnapshotRestorePreview;
 
 beforeAll(async () => {
   ({ buildSnapshotPayload, buildSnapshotEndpointKey, planSnapshotEndpointReconciliation } =
     await import('./service.js'));
+  ({ buildProjectSnapshotRestorePreview } = await import('./service.js'));
 });
 
 describe('project-snapshots/service helpers', () => {
@@ -226,6 +228,189 @@ describe('project-snapshots/service helpers', () => {
           ],
         },
       ],
+    });
+  });
+
+  it('preserves snapshot globalConfig scope instead of coercing it to all', () => {
+    const payload = buildSnapshotPayload({
+      id: 'project-1',
+      slug: 'users-api',
+      name: 'Users API',
+      description: 'Project snapshot',
+      globalConfig: {
+        latencyEnabled: false,
+        latencyMinMs: 0,
+        latencyMaxMs: 1000,
+        latencyMode: 'fixed',
+        errorSimulationEnabled: false,
+        errorSimulationRate: 0,
+        errorSimulationCodes: [500],
+        rateLimitingEnabled: false,
+        rateLimitingRpm: 60,
+        loggingLevel: 'basic',
+        scope: 'unset',
+      },
+      endpoints: [],
+    });
+
+    expect(payload.globalConfig.scope).toBe('unset');
+  });
+
+  it('builds a restore preview with metadata, config, and endpoint change groups', () => {
+    const preview = buildProjectSnapshotRestorePreview(
+      {
+        project: {
+          id: 'project-1',
+          slug: 'users-api',
+          name: 'Snapshot Users API',
+          description: 'Snapshot description',
+        },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: true,
+          latencyMinMs: 10,
+          latencyMaxMs: 20,
+          latencyMode: 'range',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 60,
+          loggingLevel: 'full',
+          scope: 'unset',
+        },
+        endpoints: [
+          {
+            method: 'GET',
+            path: '/users',
+            description: 'Snapshot list users',
+            statusCode: 200,
+            responseBody: [{ id: 1 }],
+            endpointConfig: {
+              latencyMode: 'fixed',
+              fixedDelayMs: 0,
+              minDelayMs: 0,
+              maxDelayMs: 500,
+              errorRate: 0,
+              useScenarioWeights: true,
+            },
+            scenarios: [],
+          },
+          {
+            method: 'POST',
+            path: '/users',
+            description: 'Create user',
+            statusCode: 201,
+            responseBody: { ok: true },
+            endpointConfig: {
+              latencyMode: 'fixed',
+              fixedDelayMs: 0,
+              minDelayMs: 0,
+              maxDelayMs: 500,
+              errorRate: 0,
+              useScenarioWeights: true,
+            },
+            scenarios: [],
+          },
+        ],
+      },
+      {
+        project: {
+          id: 'project-1',
+          slug: 'users-api',
+          name: 'Live Users API',
+          description: 'Live description',
+        },
+        globalConfig: {
+          projectId: 'project-1',
+          latencyEnabled: false,
+          latencyMinMs: 0,
+          latencyMaxMs: 1000,
+          latencyMode: 'fixed',
+          errorSimulationEnabled: false,
+          errorSimulationRate: 0,
+          errorSimulationCodes: [500],
+          rateLimitingEnabled: false,
+          rateLimitingRpm: 60,
+          loggingLevel: 'basic',
+          scope: 'all',
+        },
+        endpoints: [
+          {
+            id: 'endpoint-1',
+            method: 'GET',
+            path: '/users',
+            description: 'Live list users',
+            statusCode: 200,
+            responseBody: [],
+            endpointConfig: {
+              latencyMode: 'fixed',
+              fixedDelayMs: 0,
+              minDelayMs: 0,
+              maxDelayMs: 500,
+              errorRate: 0,
+              useScenarioWeights: true,
+            },
+            scenarios: [],
+          },
+          {
+            id: 'endpoint-2',
+            method: 'DELETE',
+            path: '/users/:id',
+            description: 'Delete user',
+            statusCode: 204,
+            responseBody: null,
+            endpointConfig: {
+              latencyMode: 'fixed',
+              fixedDelayMs: 0,
+              minDelayMs: 0,
+              maxDelayMs: 500,
+              errorRate: 0,
+              useScenarioWeights: true,
+            },
+            scenarios: [],
+          },
+        ],
+      }
+    );
+
+    expect(preview.project.name).toEqual({
+      current: 'Live Users API',
+      snapshot: 'Snapshot Users API',
+      changed: true,
+    });
+    expect(preview.project.description).toEqual({
+      current: 'Live description',
+      snapshot: 'Snapshot description',
+      changed: true,
+    });
+    expect(preview.revision).toEqual({
+      endpointCount: 2,
+      scenarioCount: 0,
+      globalScope: 'unset',
+      projectSlug: 'users-api',
+      projectName: 'Snapshot Users API',
+      isLegacySnapshot: false,
+    });
+    expect(preview.globalConfig.changed).toBe(true);
+    expect(preview.globalConfig.changes.map((entry) => entry.field)).toEqual([
+      'latencyEnabled',
+      'latencyMinMs',
+      'latencyMaxMs',
+      'latencyMode',
+      'loggingLevel',
+      'scope',
+    ]);
+    expect(preview.endpoints.create.map((entry) => entry.key)).toEqual(['POST /users']);
+    expect(preview.endpoints.update.map((entry) => entry.key)).toEqual(['GET /users']);
+    expect(preview.endpoints.delete.map((entry) => entry.key)).toEqual(['DELETE /users/:id']);
+    expect(preview.endpoints.keep).toEqual([]);
+    expect(preview.counts).toEqual({
+      create: 1,
+      update: 1,
+      delete: 1,
+      keep: 0,
+      totalAfterRestore: 2,
     });
   });
 });

--- a/apps/backend/src/management/project-snapshots/service.ts
+++ b/apps/backend/src/management/project-snapshots/service.ts
@@ -1,4 +1,4 @@
-import { authorizeProjectAccess } from '../../auth/authorization.js';
+import { authorizeProjectAccess, authorizeProjectCapability } from '../../auth/authorization.js';
 import type { AuthenticatedActor } from '../../auth/types.js';
 import { prisma } from '../../lib/prisma.js';
 import { toPrismaJson } from '../../lib/prisma-json.js';
@@ -37,7 +37,7 @@ interface SnapshotScenarioSource {
 
 interface SnapshotScenarioPayload {
   name: string;
-  type: 'success' | 'error' | 'timeout' | 'empty';
+  type: 'success' | 'error' | 'timeout' | 'empty' | 'unauthorized';
   statusCode: number;
   body: unknown;
   delayMs: number;
@@ -87,6 +87,7 @@ interface ProjectSnapshotSummary {
   name: string;
   description: string;
   createdAt: string;
+  revision: SnapshotRevisionMetadata;
   createdBy: {
     userId: string;
     email: string | null;
@@ -96,6 +97,51 @@ interface ProjectSnapshotSummary {
 
 interface ProjectSnapshotDetail extends ProjectSnapshotSummary {
   payload: ProjectSnapshotPayload;
+}
+
+interface RestorePreviewValue<T> {
+  current: T;
+  snapshot: T;
+  changed: boolean;
+}
+
+interface RestorePreviewConfigChange {
+  field: keyof Omit<SnapshotGlobalConfigPayload, 'projectId'>;
+  current: unknown;
+  snapshot: unknown;
+}
+
+interface RestorePreviewEndpointSummary {
+  key: string;
+  method: string;
+  path: string;
+}
+
+export interface ProjectSnapshotRestorePreview {
+  snapshotId: string;
+  snapshotName: string;
+  revision: SnapshotRevisionMetadata;
+  project: {
+    name: RestorePreviewValue<string>;
+    description: RestorePreviewValue<string>;
+  };
+  globalConfig: {
+    changed: boolean;
+    changes: RestorePreviewConfigChange[];
+  };
+  endpoints: {
+    create: RestorePreviewEndpointSummary[];
+    update: RestorePreviewEndpointSummary[];
+    delete: RestorePreviewEndpointSummary[];
+    keep: RestorePreviewEndpointSummary[];
+  };
+  counts: {
+    create: number;
+    update: number;
+    delete: number;
+    keep: number;
+    totalAfterRestore: number;
+  };
 }
 
 interface ProjectSnapshotRecord {
@@ -110,6 +156,25 @@ interface ProjectSnapshotRecord {
   createdAt: Date;
 }
 
+interface SnapshotRevisionMetadata {
+  endpointCount: number;
+  scenarioCount: number;
+  globalScope: 'all' | 'unset' | null;
+  projectSlug: string | null;
+  projectName: string | null;
+  isLegacySnapshot: boolean;
+}
+
+interface LiveRestoreEndpoint extends SnapshotEndpointPayload {
+  id: string;
+}
+
+interface LiveProjectRestoreState {
+  project: ProjectSnapshotPayload['project'];
+  globalConfig: SnapshotGlobalConfigPayload;
+  endpoints: LiveRestoreEndpoint[];
+}
+
 const DEFAULT_ENDPOINT_CONFIG: SnapshotEndpointConfigPayload = {
   latencyMode: 'fixed',
   fixedDelayMs: 0,
@@ -121,6 +186,110 @@ const DEFAULT_ENDPOINT_CONFIG: SnapshotEndpointConfigPayload = {
 
 export function buildSnapshotEndpointKey(method: string, path: string): string {
   return `${method.trim().toUpperCase()} ${path.trim()}`;
+}
+
+function toStableJson(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+function toEndpointSummary(endpoint: {
+  method: string;
+  path: string;
+}): RestorePreviewEndpointSummary {
+  return {
+    key: buildSnapshotEndpointKey(endpoint.method, endpoint.path),
+    method: endpoint.method.toUpperCase(),
+    path: endpoint.path,
+  };
+}
+
+function toSnapshotRevisionMetadata(payload: unknown): SnapshotRevisionMetadata {
+  const snapshotPayload = payload as Partial<ProjectSnapshotPayload> | null | undefined;
+  const endpoints = Array.isArray(snapshotPayload?.endpoints) ? snapshotPayload.endpoints : null;
+  const globalScope =
+    snapshotPayload?.globalConfig?.scope === 'all' ||
+    snapshotPayload?.globalConfig?.scope === 'unset'
+      ? snapshotPayload.globalConfig.scope
+      : null;
+
+  return {
+    endpointCount: endpoints?.length ?? 0,
+    scenarioCount:
+      endpoints?.reduce(
+        (total, endpoint) =>
+          total + (Array.isArray(endpoint?.scenarios) ? endpoint.scenarios.length : 0),
+        0
+      ) ?? 0,
+    globalScope,
+    projectSlug:
+      typeof snapshotPayload?.project?.slug === 'string' ? snapshotPayload.project.slug : null,
+    projectName:
+      typeof snapshotPayload?.project?.name === 'string' ? snapshotPayload.project.name : null,
+    isLegacySnapshot: !snapshotPayload?.project || !endpoints || !snapshotPayload?.globalConfig,
+  };
+}
+
+function areSnapshotEndpointsEquivalent(
+  snapshotEndpoint: SnapshotEndpointPayload,
+  liveEndpoint: SnapshotEndpointPayload
+): boolean {
+  return (
+    snapshotEndpoint.description === liveEndpoint.description &&
+    snapshotEndpoint.statusCode === liveEndpoint.statusCode &&
+    toStableJson(snapshotEndpoint.responseBody) === toStableJson(liveEndpoint.responseBody) &&
+    toStableJson(snapshotEndpoint.endpointConfig) === toStableJson(liveEndpoint.endpointConfig) &&
+    toStableJson(snapshotEndpoint.scenarios) === toStableJson(liveEndpoint.scenarios)
+  );
+}
+
+function buildEndpointRestorePlan(
+  snapshotEndpoints: SnapshotEndpointPayload[],
+  liveEndpoints: LiveRestoreEndpoint[]
+) {
+  const snapshotByKey = new Map(
+    snapshotEndpoints.map((endpoint) => [
+      buildSnapshotEndpointKey(endpoint.method, endpoint.path),
+      endpoint,
+    ])
+  );
+  const liveByKey = new Map(
+    liveEndpoints.map((endpoint) => [
+      buildSnapshotEndpointKey(endpoint.method, endpoint.path),
+      endpoint,
+    ])
+  );
+
+  const create: SnapshotEndpointPayload[] = [];
+  const update: Array<{ snapshot: SnapshotEndpointPayload; live: LiveRestoreEndpoint }> = [];
+  const keep: Array<{ snapshot: SnapshotEndpointPayload; live: LiveRestoreEndpoint }> = [];
+
+  for (const snapshotEndpoint of snapshotEndpoints) {
+    const key = buildSnapshotEndpointKey(snapshotEndpoint.method, snapshotEndpoint.path);
+    const liveEndpoint = liveByKey.get(key);
+    if (!liveEndpoint) {
+      create.push(snapshotEndpoint);
+      continue;
+    }
+
+    if (areSnapshotEndpointsEquivalent(snapshotEndpoint, liveEndpoint)) {
+      keep.push({ snapshot: snapshotEndpoint, live: liveEndpoint });
+      continue;
+    }
+
+    update.push({ snapshot: snapshotEndpoint, live: liveEndpoint });
+  }
+
+  const deleted = liveEndpoints.filter(
+    (endpoint) => !snapshotByKey.has(buildSnapshotEndpointKey(endpoint.method, endpoint.path))
+  );
+
+  return {
+    create,
+    update,
+    keep,
+    delete: deleted,
+    deleteIds: deleted.map((endpoint) => endpoint.id),
+  };
 }
 
 export function planSnapshotEndpointReconciliation(
@@ -187,6 +356,7 @@ function toSnapshotSummary(snapshot: ProjectSnapshotRecord): ProjectSnapshotSumm
     name: snapshot.name,
     description: snapshot.description,
     createdAt: snapshot.createdAt.toISOString(),
+    revision: toSnapshotRevisionMetadata(snapshot.payload),
     createdBy: {
       userId: snapshot.createdByUserId,
       email: snapshot.createdByEmail,
@@ -244,7 +414,72 @@ function normalizeSnapshotGlobalConfig(
       config?.loggingLevel === 'full' || config?.loggingLevel === 'off'
         ? config.loggingLevel
         : defaults.loggingLevel,
-    scope: config?.scope === 'unset' ? 'unset' : 'all',
+    scope: config?.scope === 'unset' || config?.scope === 'all' ? config.scope : defaults.scope,
+  };
+}
+
+function toRestorePreviewValue<T>(current: T, snapshot: T): RestorePreviewValue<T> {
+  return {
+    current,
+    snapshot,
+    changed: toStableJson(current) !== toStableJson(snapshot),
+  };
+}
+
+const RESTORE_PREVIEW_GLOBAL_CONFIG_FIELDS: Array<
+  keyof Omit<SnapshotGlobalConfigPayload, 'projectId'>
+> = [
+  'latencyEnabled',
+  'latencyMinMs',
+  'latencyMaxMs',
+  'latencyMode',
+  'errorSimulationEnabled',
+  'errorSimulationRate',
+  'errorSimulationCodes',
+  'rateLimitingEnabled',
+  'rateLimitingRpm',
+  'loggingLevel',
+  'scope',
+];
+
+export function buildProjectSnapshotRestorePreview(
+  snapshot: ProjectSnapshotPayload,
+  live: LiveProjectRestoreState,
+  snapshotMeta?: { id: string; name: string }
+): ProjectSnapshotRestorePreview {
+  const name = toRestorePreviewValue(live.project.name, snapshot.project.name);
+  const description = toRestorePreviewValue(live.project.description, snapshot.project.description);
+  const configChanges = RESTORE_PREVIEW_GLOBAL_CONFIG_FIELDS.flatMap((field) => {
+    const current = live.globalConfig[field];
+    const next = snapshot.globalConfig[field];
+    return toStableJson(current) === toStableJson(next)
+      ? []
+      : [{ field, current, snapshot: next } satisfies RestorePreviewConfigChange];
+  });
+  const endpointPlan = buildEndpointRestorePlan(snapshot.endpoints, live.endpoints);
+
+  return {
+    snapshotId: snapshotMeta?.id ?? '',
+    snapshotName: snapshotMeta?.name ?? '',
+    revision: toSnapshotRevisionMetadata(snapshot),
+    project: { name, description },
+    globalConfig: {
+      changed: configChanges.length > 0,
+      changes: configChanges,
+    },
+    endpoints: {
+      create: endpointPlan.create.map(toEndpointSummary),
+      update: endpointPlan.update.map(({ snapshot: endpoint }) => toEndpointSummary(endpoint)),
+      delete: endpointPlan.delete.map(toEndpointSummary),
+      keep: endpointPlan.keep.map(({ snapshot: endpoint }) => toEndpointSummary(endpoint)),
+    },
+    counts: {
+      create: endpointPlan.create.length,
+      update: endpointPlan.update.length,
+      delete: endpointPlan.delete.length,
+      keep: endpointPlan.keep.length,
+      totalAfterRestore: snapshot.endpoints.length,
+    },
   };
 }
 
@@ -288,7 +523,10 @@ export function buildSnapshotPayload(project: {
         scenarios: endpoint.scenarios.map((scenario) => ({
           name: scenario.name,
           type:
-            scenario.type === 'error' || scenario.type === 'timeout' || scenario.type === 'empty'
+            scenario.type === 'error' ||
+            scenario.type === 'timeout' ||
+            scenario.type === 'empty' ||
+            scenario.type === 'unauthorized'
               ? scenario.type
               : 'success',
           statusCode: scenario.statusCode,
@@ -315,6 +553,42 @@ async function loadSnapshotRecord(
   return snapshot as ProjectSnapshotRecord;
 }
 
+async function loadLiveProjectRestoreState(projectId: string): Promise<LiveProjectRestoreState> {
+  const project = await prisma.project.findUnique({
+    where: { id: projectId },
+    include: {
+      globalConfig: true,
+      endpoints: {
+        include: {
+          endpointConfig: true,
+          scenarios: {
+            orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+          },
+        },
+        orderBy: [{ method: 'asc' }, { path: 'asc' }, { id: 'asc' }],
+      },
+    },
+  });
+
+  if (!project) {
+    throw new AppError(404, 'Project not found');
+  }
+
+  return {
+    project: {
+      id: project.id,
+      slug: project.slug,
+      name: project.name,
+      description: project.description,
+    },
+    globalConfig: normalizeSnapshotGlobalConfig(projectId, project.globalConfig),
+    endpoints: buildSnapshotPayload(project).endpoints.map((endpoint, index) => ({
+      id: project.endpoints[index]!.id,
+      ...endpoint,
+    })),
+  };
+}
+
 export async function listProjectSnapshots(actor: AuthenticatedActor, projectId: string) {
   await authorizeProjectAccess(actor, projectId, 'read');
 
@@ -336,6 +610,21 @@ export async function getProjectSnapshotDetail(
   await authorizeProjectAccess(actor, projectId, 'read');
   const snapshot = await loadSnapshotRecord(projectId, snapshotId);
   return toSnapshotDetail(snapshot);
+}
+
+export async function getProjectSnapshotRestorePreview(
+  actor: AuthenticatedActor,
+  projectId: string,
+  snapshotId: string
+) {
+  await authorizeProjectAccess(actor, projectId, 'read');
+  const snapshot = await loadSnapshotRecord(projectId, snapshotId);
+  const detail = toSnapshotDetail(snapshot);
+  const live = await loadLiveProjectRestoreState(projectId);
+  return buildProjectSnapshotRestorePreview(detail.payload, live, {
+    id: snapshot.id,
+    name: snapshot.name,
+  });
 }
 
 export async function createProjectSnapshot(
@@ -386,10 +675,15 @@ export async function createProjectSnapshot(
       resourceType: 'snapshot',
       resourceId: snapshot.id,
       action: 'created',
-      summary: `Created snapshot ${snapshot.name}`,
+      summary: `Created revision ${snapshot.name}`,
       metadata: {
         snapshotName: snapshot.name,
         endpointCount: payload.endpoints.length,
+        scenarioCount: payload.endpoints.reduce(
+          (total, endpoint) => total + endpoint.scenarios.length,
+          0
+        ),
+        scope: payload.globalConfig.scope,
       },
     });
 
@@ -402,9 +696,11 @@ export async function restoreProjectSnapshot(
   projectId: string,
   snapshotId: string
 ) {
-  const projectAccess = await authorizeProjectAccess(actor, projectId, 'mutate');
+  const projectAccess = await authorizeProjectCapability(actor, projectId, 'canRestoreSnapshots');
   const snapshot = await loadSnapshotRecord(projectId, snapshotId);
   const detail = toSnapshotDetail(snapshot);
+  const live = await loadLiveProjectRestoreState(projectId);
+  const plan = buildEndpointRestorePlan(detail.payload.endpoints, live.endpoints);
 
   await prisma.$transaction(async (tx) => {
     await tx.project.update({
@@ -428,7 +724,7 @@ export async function restoreProjectSnapshot(
         rateLimitingEnabled: detail.payload.globalConfig.rateLimitingEnabled,
         rateLimitingRpm: detail.payload.globalConfig.rateLimitingRpm,
         loggingLevel: detail.payload.globalConfig.loggingLevel,
-        scope: 'all',
+        scope: detail.payload.globalConfig.scope,
       },
       create: {
         projectId,
@@ -442,46 +738,70 @@ export async function restoreProjectSnapshot(
         rateLimitingEnabled: detail.payload.globalConfig.rateLimitingEnabled,
         rateLimitingRpm: detail.payload.globalConfig.rateLimitingRpm,
         loggingLevel: detail.payload.globalConfig.loggingLevel,
-        scope: 'all',
+        scope: detail.payload.globalConfig.scope,
       },
     });
 
-    const liveEndpoints = await tx.endpoint.findMany({
-      where: { projectId },
-      select: { id: true, method: true, path: true },
-    });
-    const plan = planSnapshotEndpointReconciliation(detail.payload.endpoints, liveEndpoints);
-    const liveByKey = new Map(
-      liveEndpoints.map((endpoint) => [
-        buildSnapshotEndpointKey(endpoint.method, endpoint.path),
-        endpoint,
-      ])
-    );
+    for (const endpoint of plan.update) {
+      const restored = await tx.endpoint.update({
+        where: { id: endpoint.live.id },
+        data: {
+          description: endpoint.snapshot.description,
+          statusCode: endpoint.snapshot.statusCode,
+          responseBody: toPrismaJson(endpoint.snapshot.responseBody),
+        },
+        select: { id: true },
+      });
 
-    for (const endpoint of detail.payload.endpoints) {
-      const key = buildSnapshotEndpointKey(endpoint.method, endpoint.path);
-      const existing = liveByKey.get(key);
-      const restored = existing
-        ? await tx.endpoint.update({
-            where: { id: existing.id },
-            data: {
-              description: endpoint.description,
-              statusCode: endpoint.statusCode,
-              responseBody: toPrismaJson(endpoint.responseBody),
-            },
-            select: { id: true },
-          })
-        : await tx.endpoint.create({
-            data: {
-              projectId,
-              method: endpoint.method,
-              path: endpoint.path,
-              description: endpoint.description,
-              statusCode: endpoint.statusCode,
-              responseBody: toPrismaJson(endpoint.responseBody),
-            },
-            select: { id: true },
-          });
+      await tx.endpointConfig.upsert({
+        where: { endpointId: restored.id },
+        update: {
+          latencyMode: endpoint.snapshot.endpointConfig.latencyMode,
+          fixedDelayMs: endpoint.snapshot.endpointConfig.fixedDelayMs,
+          minDelayMs: endpoint.snapshot.endpointConfig.minDelayMs,
+          maxDelayMs: endpoint.snapshot.endpointConfig.maxDelayMs,
+          errorRate: endpoint.snapshot.endpointConfig.errorRate,
+          useScenarioWeights: endpoint.snapshot.endpointConfig.useScenarioWeights,
+        },
+        create: {
+          endpointId: restored.id,
+          latencyMode: endpoint.snapshot.endpointConfig.latencyMode,
+          fixedDelayMs: endpoint.snapshot.endpointConfig.fixedDelayMs,
+          minDelayMs: endpoint.snapshot.endpointConfig.minDelayMs,
+          maxDelayMs: endpoint.snapshot.endpointConfig.maxDelayMs,
+          errorRate: endpoint.snapshot.endpointConfig.errorRate,
+          useScenarioWeights: endpoint.snapshot.endpointConfig.useScenarioWeights,
+        },
+      });
+
+      await tx.scenario.deleteMany({ where: { endpointId: restored.id } });
+      if (endpoint.snapshot.scenarios.length > 0) {
+        await tx.scenario.createMany({
+          data: endpoint.snapshot.scenarios.map((scenario) => ({
+            endpointId: restored.id,
+            name: scenario.name,
+            type: scenario.type,
+            statusCode: scenario.statusCode,
+            body: toPrismaJson(scenario.body),
+            delayMs: scenario.delayMs,
+            weight: scenario.weight,
+          })),
+        });
+      }
+    }
+
+    for (const endpoint of plan.create) {
+      const restored = await tx.endpoint.create({
+        data: {
+          projectId,
+          method: endpoint.method,
+          path: endpoint.path,
+          description: endpoint.description,
+          statusCode: endpoint.statusCode,
+          responseBody: toPrismaJson(endpoint.responseBody),
+        },
+        select: { id: true },
+      });
 
       await tx.endpointConfig.upsert({
         where: { endpointId: restored.id },
@@ -531,11 +851,16 @@ export async function restoreProjectSnapshot(
       resourceType: 'snapshot',
       resourceId: snapshot.id,
       action: 'restored',
-      summary: `Restored snapshot ${snapshot.name}`,
+      summary: `Restored revision ${snapshot.name}`,
       metadata: {
         snapshotName: snapshot.name,
         restoredEndpointCount: detail.payload.endpoints.length,
         deletedEndpointCount: plan.deleteIds.length,
+        scenarioCount: detail.payload.endpoints.reduce(
+          (total, endpoint) => total + endpoint.scenarios.length,
+          0
+        ),
+        scope: detail.payload.globalConfig.scope,
       },
     });
   });

--- a/apps/backend/src/management/projects/schema.ts
+++ b/apps/backend/src/management/projects/schema.ts
@@ -19,13 +19,24 @@ export const listProjectsQuerySchema = z.object({
 export const createProjectSchema = z.object({
   name: z.string().min(1).max(100),
   description: z.string().max(500).optional(),
+  workspaceId: z.string().min(1).optional(),
 });
 
 export const updateProjectSchema = createProjectSchema
+  .extend({
+    slug: z.string().trim().min(1).max(100).optional(),
+  })
   .partial()
-  .refine((input) => input.name !== undefined || input.description !== undefined, {
-    message: 'At least one field (name or description) is required',
-  });
+  .refine(
+    (input) =>
+      input.name !== undefined ||
+      input.description !== undefined ||
+      input.slug !== undefined ||
+      input.workspaceId !== undefined,
+    {
+      message: 'At least one field (name, description, slug or workspaceId) is required',
+    }
+  );
 
 export type CreateProjectInput = z.infer<typeof createProjectSchema>;
 export type UpdateProjectInput = z.infer<typeof updateProjectSchema>;

--- a/apps/backend/src/management/projects/service.ts
+++ b/apps/backend/src/management/projects/service.ts
@@ -2,14 +2,14 @@ import {
   getAccessibleWorkspaceIds,
   authorizeProjectAccess,
   requireWorkspaceAccess,
-  resolveWorkspaceAccess,
+  summarizeWorkspaceAccess,
   resolveDefaultWorkspaceId,
 } from '../../auth/authorization.js';
 import type { AuthenticatedActor } from '../../auth/types.js';
 import { prisma } from '../../lib/prisma.js';
 import { AppError } from '../../middleware/error-handler.js';
 import { writeAuditEvent } from '../audit-events/service.js';
-import { buildBaseSlug, resolveNextAvailableSlug } from './slug.js';
+import { buildBaseSlug, isReservedSlug, resolveNextAvailableSlug } from './slug.js';
 import type { CreateProjectInput, ListProjectsQueryInput, UpdateProjectInput } from './schema.js';
 
 type PagedResult<T> = {
@@ -64,6 +64,13 @@ export async function listProjects(
       skip: query.offset,
       take: query.limit,
       include: {
+        workspace: {
+          select: {
+            id: true,
+            name: true,
+            kind: true,
+          },
+        },
         _count: {
           select: { endpoints: true },
         },
@@ -75,7 +82,7 @@ export async function listProjects(
   return {
     items: items.map((project) => ({
       ...project,
-      workspace: resolveWorkspaceAccess(actor, project.workspaceId),
+      workspace: summarizeWorkspaceAccess(actor, project.workspace ?? project.workspaceId),
     })),
     page: {
       limit: query.limit,
@@ -91,7 +98,7 @@ export async function getProjectById(actor: AuthenticatedActor, projectId: strin
     where: { id: projectId },
     include: {
       workspace: {
-        select: { id: true },
+        select: { id: true, name: true, kind: true },
       },
       globalConfig: true,
       _count: {
@@ -108,13 +115,15 @@ export async function getProjectById(actor: AuthenticatedActor, projectId: strin
 
   return {
     ...project,
-    workspace: resolveWorkspaceAccess(actor, project.workspaceId),
+    workspace: summarizeWorkspaceAccess(actor, project.workspace ?? project.workspaceId),
   };
 }
 
 export async function createProject(actor: AuthenticatedActor, input: CreateProjectInput) {
+  const workspaceId = input.workspaceId
+    ? requireWorkspaceAccess(actor, input.workspaceId, 'mutate')
+    : resolveDefaultWorkspaceId(actor);
   const slug = await generateUniqueProjectSlug(input.name);
-  const workspaceId = resolveDefaultWorkspaceId(actor);
 
   return prisma.$transaction(async (tx) => {
     const createdProject = await tx.project.create({
@@ -149,6 +158,13 @@ export async function createProject(actor: AuthenticatedActor, input: CreateProj
     const project = await tx.project.findUniqueOrThrow({
       where: { id: createdProject.id },
       include: {
+        workspace: {
+          select: {
+            id: true,
+            name: true,
+            kind: true,
+          },
+        },
         globalConfig: true,
         _count: {
           select: { endpoints: true },
@@ -158,7 +174,11 @@ export async function createProject(actor: AuthenticatedActor, input: CreateProj
 
     return {
       ...project,
-      workspace: resolveWorkspaceAccess(actor, project.workspaceId),
+      workspace: summarizeWorkspaceAccess(
+        actor,
+        project.workspace ?? project.workspaceId,
+        'mutate'
+      ),
     };
   });
 }
@@ -168,16 +188,66 @@ export async function updateProject(
   projectId: string,
   input: UpdateProjectInput
 ) {
-  await authorizeProjectAccess(actor, projectId, 'mutate');
+  const authorizedProject = await authorizeProjectAccess(actor, projectId, 'mutate');
+  const requestedWorkspaceId = input.workspaceId?.trim();
+  const transferWorkspaceId =
+    requestedWorkspaceId && requestedWorkspaceId !== authorizedProject.workspaceId
+      ? requireWorkspaceAccess(actor, requestedWorkspaceId, 'mutate')
+      : undefined;
 
   const project = await prisma.$transaction(async (tx) => {
+    const currentProject = await tx.project.findUniqueOrThrow({
+      where: { id: projectId },
+      select: {
+        id: true,
+        slug: true,
+        workspaceId: true,
+        workspace: {
+          select: {
+            id: true,
+            name: true,
+            kind: true,
+          },
+        },
+      },
+    });
+    const normalizedSlug = input.slug === undefined ? undefined : buildBaseSlug(input.slug);
+
+    if (normalizedSlug !== undefined) {
+      if (isReservedSlug(normalizedSlug)) {
+        throw new AppError(409, 'Project slug is reserved', {
+          code: 'PROJECT_SLUG_RESERVED',
+        });
+      }
+
+      const slugOwner = await tx.project.findUnique({
+        where: { slug: normalizedSlug },
+        select: { id: true },
+      });
+
+      if (slugOwner && slugOwner.id !== projectId) {
+        throw new AppError(409, 'Project slug already exists', {
+          code: 'PROJECT_SLUG_DUPLICATE',
+        });
+      }
+    }
+
     const updatedProject = await tx.project.update({
       where: { id: projectId },
       data: {
         ...(input.name !== undefined ? { name: input.name } : {}),
         ...(input.description !== undefined ? { description: input.description } : {}),
+        ...(normalizedSlug !== undefined ? { slug: normalizedSlug } : {}),
+        ...(transferWorkspaceId !== undefined ? { workspaceId: transferWorkspaceId } : {}),
       },
       include: {
+        workspace: {
+          select: {
+            id: true,
+            name: true,
+            kind: true,
+          },
+        },
         globalConfig: true,
         _count: {
           select: { endpoints: true },
@@ -195,6 +265,20 @@ export async function updateProject(
       summary: `Updated project ${updatedProject.name}`,
       metadata: {
         projectName: updatedProject.name,
+        ...(normalizedSlug !== undefined && normalizedSlug !== currentProject.slug
+          ? {
+              previousProjectSlug: currentProject.slug,
+              projectSlug: updatedProject.slug,
+            }
+          : {}),
+        ...(transferWorkspaceId !== undefined
+          ? {
+              previousWorkspaceId: currentProject.workspaceId,
+              previousWorkspaceName: currentProject.workspace?.name ?? currentProject.workspaceId,
+              nextWorkspaceId: updatedProject.workspaceId,
+              nextWorkspaceName: updatedProject.workspace?.name ?? updatedProject.workspaceId,
+            }
+          : {}),
       },
     });
 
@@ -203,7 +287,7 @@ export async function updateProject(
 
   return {
     ...project,
-    workspace: resolveWorkspaceAccess(actor, project.workspaceId),
+    workspace: summarizeWorkspaceAccess(actor, project.workspace ?? project.workspaceId),
   };
 }
 

--- a/apps/backend/src/management/scenarios/schema.ts
+++ b/apps/backend/src/management/scenarios/schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const scenarioTypeSchema = z.enum(['success', 'error', 'timeout', 'empty']);
+export const scenarioTypeSchema = z.enum(['success', 'error', 'timeout', 'empty', 'unauthorized']);
 
 export const endpointParamsSchema = z.object({
   endpointId: z.string().min(1),

--- a/apps/backend/src/management/scenarios/service.test.ts
+++ b/apps/backend/src/management/scenarios/service.test.ts
@@ -28,6 +28,8 @@ import { updateScenario } from './service.js';
 
 const actor: AuthenticatedActor = {
   userId: 'user-1',
+  email: 'owner@example.com',
+  displayName: 'Owner User',
   personalWorkspaceId: 'workspace-1',
   identity: {
     provider: 'clerk',

--- a/apps/backend/src/management/workspace-invitations/router.ts
+++ b/apps/backend/src/management/workspace-invitations/router.ts
@@ -1,0 +1,83 @@
+import { Router } from 'express';
+import { requireRequestActor } from '../../auth/request-context.js';
+import {
+  acceptWorkspaceInvitationResponseSchema,
+  createWorkspaceInvitationSchema,
+  workspaceInvitationParamsSchema,
+  workspaceInvitationResponseSchema,
+  workspaceInvitationWorkspaceMemberParamsSchema,
+  workspaceInvitationWorkspaceParamsSchema,
+  workspaceInvitationsListSchema,
+} from './schema.js';
+import {
+  acceptWorkspaceInvitation,
+  createWorkspaceInvitation,
+  listPendingWorkspaceInvitations,
+  listWorkspaceInvitations,
+  revokeWorkspaceInvitation,
+} from './service.js';
+
+export const workspaceInvitationsRouter = Router();
+export const workspaceScopedInvitationsRouter = Router({ mergeParams: true });
+
+workspaceScopedInvitationsRouter.get('/', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { workspaceId } = workspaceInvitationWorkspaceParamsSchema.parse(req.params);
+    const invitations = await listWorkspaceInvitations(actor, workspaceId);
+
+    res.status(200).json(workspaceInvitationsListSchema.parse(invitations));
+  } catch (error) {
+    next(error);
+  }
+});
+
+workspaceScopedInvitationsRouter.post('/', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { workspaceId } = workspaceInvitationWorkspaceParamsSchema.parse(req.params);
+    const input = createWorkspaceInvitationSchema.parse(req.body);
+    const invitation = await createWorkspaceInvitation(actor, workspaceId, input);
+
+    res.status(201).json(workspaceInvitationResponseSchema.parse(invitation));
+  } catch (error) {
+    next(error);
+  }
+});
+
+workspaceScopedInvitationsRouter.delete('/:invitationId', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { workspaceId, invitationId } = workspaceInvitationWorkspaceMemberParamsSchema.parse(
+      req.params
+    );
+    await revokeWorkspaceInvitation(actor, workspaceId, invitationId);
+
+    res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+workspaceInvitationsRouter.get('/pending', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const invitations = await listPendingWorkspaceInvitations(actor);
+
+    res.status(200).json(workspaceInvitationsListSchema.parse(invitations));
+  } catch (error) {
+    next(error);
+  }
+});
+
+workspaceInvitationsRouter.post('/:invitationId/accept', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { invitationId } = workspaceInvitationParamsSchema.parse(req.params);
+    const result = await acceptWorkspaceInvitation(actor, invitationId);
+
+    res.status(200).json(acceptWorkspaceInvitationResponseSchema.parse(result));
+  } catch (error) {
+    next(error);
+  }
+});

--- a/apps/backend/src/management/workspace-invitations/schema.ts
+++ b/apps/backend/src/management/workspace-invitations/schema.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+import { workspaceRoleSchema } from '../workspace-members/schema.js';
+
+export const workspaceInvitationStatusSchema = z.enum(['pending', 'accepted', 'revoked']);
+export const workspaceInvitationRoleSchema = z.enum(['viewer', 'editor']);
+
+export const workspaceInvitationParamsSchema = z.object({
+  invitationId: z.string().min(1),
+});
+
+export const workspaceInvitationWorkspaceParamsSchema = z.object({
+  workspaceId: z.string().min(1),
+});
+
+export const workspaceInvitationWorkspaceMemberParamsSchema =
+  workspaceInvitationWorkspaceParamsSchema.extend({
+    invitationId: z.string().min(1),
+  });
+
+export const createWorkspaceInvitationSchema = z.object({
+  email: z.string().email().max(320),
+  role: workspaceInvitationRoleSchema,
+});
+
+export const workspaceInvitationResponseSchema = z.object({
+  id: z.string(),
+  workspaceId: z.string(),
+  workspaceName: z.string(),
+  email: z.string().email(),
+  role: workspaceRoleSchema,
+  status: workspaceInvitationStatusSchema,
+  createdAt: z.string().datetime(),
+});
+
+export const workspaceInvitationsListSchema = z.object({
+  items: z.array(workspaceInvitationResponseSchema),
+});
+
+export const acceptWorkspaceInvitationResponseSchema = z.object({
+  accepted: z.literal(true),
+});
+
+export type CreateWorkspaceInvitationInput = z.infer<typeof createWorkspaceInvitationSchema>;

--- a/apps/backend/src/management/workspace-invitations/service.ts
+++ b/apps/backend/src/management/workspace-invitations/service.ts
@@ -1,0 +1,325 @@
+import { Prisma } from '@prisma/client';
+import { requireWorkspaceAccess } from '../../auth/authorization.js';
+import type { AuthenticatedActor, WorkspaceRole } from '../../auth/types.js';
+import { prisma } from '../../lib/prisma.js';
+import { AppError } from '../../middleware/error-handler.js';
+import type { CreateWorkspaceInvitationInput } from './schema.js';
+
+function normalizeWorkspaceRole(role: string): WorkspaceRole {
+  return role === 'owner' || role === 'editor' ? role : 'viewer';
+}
+
+function requireInvitableRole(role: string): 'viewer' | 'editor' {
+  if (role === 'viewer' || role === 'editor') {
+    return role;
+  }
+
+  throw new AppError(400, 'Invitation role must be viewer or editor', {
+    code: 'WORKSPACE_INVITATION_ROLE_NOT_INVITABLE',
+  });
+}
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function requireActorEmail(actor: AuthenticatedActor): string {
+  const email = normalizeEmail(actor.email ?? '');
+
+  if (!email) {
+    throw new AppError(400, 'Authenticated users must have an email for invitation flows', {
+      code: 'AUTHENTICATED_EMAIL_REQUIRED',
+    });
+  }
+
+  return email;
+}
+
+function toWorkspaceInvitationDto(invitation: {
+  id: string;
+  workspaceId: string;
+  email: string;
+  role: string;
+  status: 'pending' | 'accepted' | 'revoked';
+  createdAt: Date;
+  workspace: { id: string; name: string };
+}) {
+  return {
+    id: invitation.id,
+    workspaceId: invitation.workspaceId,
+    workspaceName: invitation.workspace.name,
+    email: invitation.email,
+    role: normalizeWorkspaceRole(invitation.role),
+    status: invitation.status,
+    createdAt: invitation.createdAt.toISOString(),
+  };
+}
+
+function mapPendingInvitationConflict(status: string): never {
+  if (status === 'accepted') {
+    throw new AppError(409, 'Invitation was already accepted', {
+      code: 'WORKSPACE_INVITATION_ALREADY_ACCEPTED',
+    });
+  }
+
+  if (status === 'revoked') {
+    throw new AppError(409, 'Invitation was already revoked', {
+      code: 'WORKSPACE_INVITATION_ALREADY_REVOKED',
+    });
+  }
+
+  throw new AppError(409, 'Invitation is no longer pending', {
+    code: 'WORKSPACE_INVITATION_NOT_PENDING',
+  });
+}
+
+export async function listWorkspaceInvitations(actor: AuthenticatedActor, workspaceId: string) {
+  requireWorkspaceAccess(actor, workspaceId, 'owner');
+
+  const items = await prisma.workspaceInvitation.findMany({
+    where: { workspaceId },
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    select: {
+      id: true,
+      workspaceId: true,
+      email: true,
+      role: true,
+      status: true,
+      createdAt: true,
+      workspace: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  return {
+    items: items.map((item) =>
+      toWorkspaceInvitationDto({
+        ...item,
+        status: item.status === 'accepted' || item.status === 'revoked' ? item.status : 'pending',
+      })
+    ),
+  };
+}
+
+export async function createWorkspaceInvitation(
+  actor: AuthenticatedActor,
+  workspaceId: string,
+  input: CreateWorkspaceInvitationInput
+) {
+  requireWorkspaceAccess(actor, workspaceId, 'owner');
+
+  const invitationRole = requireInvitableRole(input.role);
+  const normalizedEmail = normalizeEmail(input.email);
+  const existingMembership = await prisma.workspaceMembership.findFirst({
+    where: {
+      workspaceId,
+      user: {
+        email: {
+          equals: normalizedEmail,
+          mode: 'insensitive',
+        },
+      },
+    },
+    select: { userId: true },
+  });
+
+  if (existingMembership) {
+    throw new AppError(409, 'User is already a workspace member', {
+      code: 'WORKSPACE_MEMBER_ALREADY_EXISTS',
+    });
+  }
+
+  const existingPendingInvitation = await prisma.workspaceInvitation.findFirst({
+    where: {
+      workspaceId,
+      email: normalizedEmail,
+      status: 'pending',
+    },
+    select: { id: true },
+  });
+
+  if (existingPendingInvitation) {
+    throw new AppError(409, 'A pending invitation already exists for that email', {
+      code: 'WORKSPACE_INVITATION_ALREADY_PENDING',
+    });
+  }
+
+  try {
+    const invitation = await prisma.workspaceInvitation.create({
+      data: {
+        workspaceId,
+        email: normalizedEmail,
+        role: invitationRole,
+        status: 'pending',
+        invitedByUserId: actor.userId,
+      },
+      select: {
+        id: true,
+        workspaceId: true,
+        email: true,
+        role: true,
+        status: true,
+        createdAt: true,
+        workspace: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+
+    return toWorkspaceInvitationDto({
+      ...invitation,
+      status: 'pending',
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      throw new AppError(409, 'A pending invitation already exists for that email', {
+        code: 'WORKSPACE_INVITATION_ALREADY_PENDING',
+      });
+    }
+
+    throw error;
+  }
+}
+
+export async function revokeWorkspaceInvitation(
+  actor: AuthenticatedActor,
+  workspaceId: string,
+  invitationId: string
+) {
+  requireWorkspaceAccess(actor, workspaceId, 'owner');
+
+  const invitation = await prisma.workspaceInvitation.findUnique({
+    where: { id: invitationId },
+    select: {
+      id: true,
+      workspaceId: true,
+      status: true,
+    },
+  });
+
+  if (!invitation || invitation.workspaceId !== workspaceId) {
+    throw new AppError(404, 'Workspace invitation not found', {
+      code: 'WORKSPACE_INVITATION_NOT_FOUND',
+    });
+  }
+
+  if (invitation.status !== 'pending') {
+    mapPendingInvitationConflict(invitation.status);
+  }
+
+  await prisma.workspaceInvitation.update({
+    where: { id: invitationId },
+    data: {
+      status: 'revoked',
+      revokedAt: new Date(),
+    },
+  });
+}
+
+export async function listPendingWorkspaceInvitations(actor: AuthenticatedActor) {
+  const actorEmail = requireActorEmail(actor);
+  const items = await prisma.workspaceInvitation.findMany({
+    where: {
+      email: actorEmail,
+      status: 'pending',
+    },
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    select: {
+      id: true,
+      workspaceId: true,
+      email: true,
+      role: true,
+      status: true,
+      createdAt: true,
+      workspace: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  return {
+    items: items.map((item) =>
+      toWorkspaceInvitationDto({
+        ...item,
+        status: 'pending',
+      })
+    ),
+  };
+}
+
+export async function acceptWorkspaceInvitation(actor: AuthenticatedActor, invitationId: string) {
+  const actorEmail = requireActorEmail(actor);
+  const invitation = await prisma.workspaceInvitation.findUnique({
+    where: { id: invitationId },
+    select: {
+      id: true,
+      workspaceId: true,
+      email: true,
+      role: true,
+      status: true,
+    },
+  });
+
+  if (!invitation) {
+    throw new AppError(404, 'Workspace invitation not found', {
+      code: 'WORKSPACE_INVITATION_NOT_FOUND',
+    });
+  }
+
+  if (invitation.status !== 'pending') {
+    mapPendingInvitationConflict(invitation.status);
+  }
+
+  if (normalizeEmail(invitation.email) !== actorEmail) {
+    throw new AppError(403, 'Invitation email does not match the authenticated user', {
+      code: 'WORKSPACE_INVITATION_EMAIL_MISMATCH',
+    });
+  }
+
+  await prisma.$transaction(async (tx) => {
+    const existingMembership = await tx.workspaceMembership.findUnique({
+      where: {
+        workspaceId_userId: {
+          workspaceId: invitation.workspaceId,
+          userId: actor.userId,
+        },
+      },
+      select: { userId: true },
+    });
+
+    if (existingMembership) {
+      throw new AppError(409, 'User is already a workspace member', {
+        code: 'WORKSPACE_MEMBER_ALREADY_EXISTS',
+      });
+    }
+
+    await tx.workspaceMembership.create({
+      data: {
+        workspaceId: invitation.workspaceId,
+        userId: actor.userId,
+        role: normalizeWorkspaceRole(invitation.role),
+      },
+    });
+
+    await tx.workspaceInvitation.update({
+      where: { id: invitationId },
+      data: {
+        status: 'accepted',
+        acceptedByUserId: actor.userId,
+        acceptedAt: new Date(),
+      },
+    });
+  });
+
+  return { accepted: true as const };
+}

--- a/apps/backend/src/management/workspace-members/router.ts
+++ b/apps/backend/src/management/workspace-members/router.ts
@@ -2,12 +2,18 @@ import { Router } from 'express';
 import { requireRequestActor } from '../../auth/request-context.js';
 import {
   addWorkspaceMemberSchema,
+  updateWorkspaceMemberRoleSchema,
   workspaceMemberParamsSchema,
   workspaceMemberResponseSchema,
   workspaceMembersListSchema,
   workspaceParamsSchema,
 } from './schema.js';
-import { addWorkspaceMember, listWorkspaceMembers, removeWorkspaceMember } from './service.js';
+import {
+  addWorkspaceMember,
+  listWorkspaceMembers,
+  removeWorkspaceMember,
+  updateWorkspaceMemberRole,
+} from './service.js';
 
 export const workspaceMembersRouter = Router({ mergeParams: true });
 
@@ -43,6 +49,19 @@ workspaceMembersRouter.delete('/:memberUserId', async (req, res, next) => {
     await removeWorkspaceMember(actor, workspaceId, memberUserId);
 
     res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+});
+
+workspaceMembersRouter.patch('/:memberUserId', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const { workspaceId, memberUserId } = workspaceMemberParamsSchema.parse(req.params);
+    const input = updateWorkspaceMemberRoleSchema.parse(req.body);
+    const member = await updateWorkspaceMemberRole(actor, workspaceId, memberUserId, input);
+
+    res.status(200).json(workspaceMemberResponseSchema.parse(member));
   } catch (error) {
     next(error);
   }

--- a/apps/backend/src/management/workspace-members/schema.ts
+++ b/apps/backend/src/management/workspace-members/schema.ts
@@ -15,6 +15,10 @@ export const addWorkspaceMemberSchema = z.object({
   role: workspaceRoleSchema,
 });
 
+export const updateWorkspaceMemberRoleSchema = z.object({
+  role: workspaceRoleSchema,
+});
+
 export const workspaceMemberResponseSchema = z.object({
   userId: z.string(),
   email: z.string().nullable(),
@@ -28,3 +32,4 @@ export const workspaceMembersListSchema = z.object({
 });
 
 export type AddWorkspaceMemberInput = z.infer<typeof addWorkspaceMemberSchema>;
+export type UpdateWorkspaceMemberRoleInput = z.infer<typeof updateWorkspaceMemberRoleSchema>;

--- a/apps/backend/src/management/workspace-members/service.ts
+++ b/apps/backend/src/management/workspace-members/service.ts
@@ -2,7 +2,7 @@ import { requireWorkspaceAccess } from '../../auth/authorization.js';
 import type { AuthenticatedActor, WorkspaceRole } from '../../auth/types.js';
 import { prisma } from '../../lib/prisma.js';
 import { AppError } from '../../middleware/error-handler.js';
-import type { AddWorkspaceMemberInput } from './schema.js';
+import type { AddWorkspaceMemberInput, UpdateWorkspaceMemberRoleInput } from './schema.js';
 
 function toWorkspaceMemberDto(member: {
   userId: string;
@@ -157,5 +157,89 @@ export async function removeWorkspaceMember(
         userId: memberUserId,
       },
     },
+  });
+}
+
+export async function updateWorkspaceMemberRole(
+  actor: AuthenticatedActor,
+  workspaceId: string,
+  memberUserId: string,
+  input: UpdateWorkspaceMemberRoleInput
+) {
+  requireWorkspaceAccess(actor, workspaceId, 'owner');
+
+  if (actor.userId === memberUserId && input.role !== 'owner') {
+    throw new AppError(409, 'Workspace owners cannot demote themselves in this flow', {
+      code: 'WORKSPACE_MEMBER_SELF_DEMOTION_BLOCKED',
+    });
+  }
+
+  const membership = await prisma.workspaceMembership.findUnique({
+    where: {
+      workspaceId_userId: {
+        workspaceId,
+        userId: memberUserId,
+      },
+    },
+    select: {
+      userId: true,
+      role: true,
+      createdAt: true,
+      user: {
+        select: {
+          email: true,
+          displayName: true,
+        },
+      },
+    },
+  });
+
+  if (!membership) {
+    throw new AppError(404, 'Workspace member not found', {
+      code: 'WORKSPACE_MEMBER_NOT_FOUND',
+    });
+  }
+
+  if (membership.role === 'owner' && input.role !== 'owner') {
+    const ownerCount = await prisma.workspaceMembership.count({
+      where: {
+        workspaceId,
+        role: 'owner',
+      },
+    });
+
+    if (ownerCount <= 1) {
+      throw new AppError(409, 'Workspaces must keep at least one owner', {
+        code: 'WORKSPACE_LAST_OWNER_REQUIRED',
+      });
+    }
+  }
+
+  const updatedMembership = await prisma.workspaceMembership.update({
+    where: {
+      workspaceId_userId: {
+        workspaceId,
+        userId: memberUserId,
+      },
+    },
+    data: {
+      role: input.role,
+    },
+    select: {
+      userId: true,
+      role: true,
+      createdAt: true,
+      user: {
+        select: {
+          email: true,
+          displayName: true,
+        },
+      },
+    },
+  });
+
+  return toWorkspaceMemberDto({
+    ...updatedMembership,
+    role: normalizeWorkspaceRole(updatedMembership.role),
   });
 }

--- a/apps/backend/src/management/workspaces/router.ts
+++ b/apps/backend/src/management/workspaces/router.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+import { requireRequestActor } from '../../auth/request-context.js';
+import { createWorkspaceSchema, workspaceListSchema, workspaceSummarySchema } from './schema.js';
+import { createWorkspace, listWorkspaces } from './service.js';
+
+export const workspacesRouter = Router();
+
+workspacesRouter.get('/', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const workspaces = await listWorkspaces(actor);
+    res.status(200).json(workspaceListSchema.parse(workspaces));
+  } catch (error) {
+    next(error);
+  }
+});
+
+workspacesRouter.post('/', async (req, res, next) => {
+  try {
+    const actor = requireRequestActor(req);
+    const input = createWorkspaceSchema.parse(req.body);
+    const workspace = await createWorkspace(actor, input);
+    res.status(201).json(workspaceSummarySchema.parse(workspace));
+  } catch (error) {
+    next(error);
+  }
+});

--- a/apps/backend/src/management/workspaces/schema.ts
+++ b/apps/backend/src/management/workspaces/schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+const workspaceRoleSchema = z.enum(['owner', 'editor', 'viewer']);
+const workspaceKindSchema = z.enum(['personal', 'team']);
+
+export const workspaceSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  kind: workspaceKindSchema,
+  role: workspaceRoleSchema,
+  isPersonal: z.boolean(),
+  capabilities: z.object({
+    canEdit: z.boolean(),
+    canManageMembers: z.boolean(),
+    canRestoreSnapshots: z.boolean(),
+    canImportContracts: z.boolean(),
+  }),
+});
+
+export const createWorkspaceSchema = z.object({
+  name: z.string().trim().min(1).max(100),
+});
+
+export const workspaceListSchema = z.object({
+  items: z.array(workspaceSummarySchema),
+});
+
+export type CreateWorkspaceInput = z.infer<typeof createWorkspaceSchema>;

--- a/apps/backend/src/management/workspaces/service.ts
+++ b/apps/backend/src/management/workspaces/service.ts
@@ -1,0 +1,64 @@
+import type { AuthenticatedActor } from '../../auth/types.js';
+import { summarizeWorkspaceAccess } from '../../auth/authorization.js';
+import { prisma } from '../../lib/prisma.js';
+import type { CreateWorkspaceInput } from './schema.js';
+
+export async function listWorkspaces(actor: AuthenticatedActor) {
+  const memberships = await prisma.workspaceMembership.findMany({
+    where: {
+      userId: actor.userId,
+    },
+    orderBy: [{ createdAt: 'asc' }, { workspaceId: 'asc' }],
+    select: {
+      workspaceId: true,
+      role: true,
+      workspace: {
+        select: {
+          id: true,
+          name: true,
+          kind: true,
+        },
+      },
+    },
+  });
+
+  return {
+    items: memberships.map((membership) => summarizeWorkspaceAccess(actor, membership.workspace)),
+  };
+}
+
+export async function createWorkspace(actor: AuthenticatedActor, input: CreateWorkspaceInput) {
+  return prisma.$transaction(async (tx) => {
+    const workspace = await tx.workspace.create({
+      data: {
+        name: input.name.trim(),
+        kind: 'team',
+      },
+      select: {
+        id: true,
+        name: true,
+        kind: true,
+      },
+    });
+
+    await tx.workspaceMembership.create({
+      data: {
+        workspaceId: workspace.id,
+        userId: actor.userId,
+        role: 'owner',
+      },
+    });
+
+    return summarizeWorkspaceAccess(
+      {
+        ...actor,
+        workspaceMemberships: [
+          ...actor.workspaceMemberships,
+          { workspaceId: workspace.id, role: 'owner' },
+        ],
+      },
+      workspace,
+      'owner'
+    );
+  });
+}

--- a/apps/backend/src/mock-server/logger.ts
+++ b/apps/backend/src/mock-server/logger.ts
@@ -7,6 +7,7 @@ export type MockLogScenarioType =
   | 'error'
   | 'timeout'
   | 'empty'
+  | 'unauthorized'
   | 'forced-error'
   | 'default'
   | 'rate-limit-block';

--- a/apps/backend/src/mock-server/mock.router.ts
+++ b/apps/backend/src/mock-server/mock.router.ts
@@ -65,7 +65,11 @@ function toAbsoluteUrl(req: Request): string {
 }
 
 function toMockScenarioType(value: string | null | undefined): MockLogInput['scenarioType'] {
-  return value === 'success' || value === 'error' || value === 'timeout' || value === 'empty'
+  return value === 'success' ||
+    value === 'error' ||
+    value === 'timeout' ||
+    value === 'empty' ||
+    value === 'unauthorized'
     ? value
     : 'default';
 }


### PR DESCRIPTION
Incluye migración Prisma, rutas REST de workspaces e invitaciones, cambios de autorización e identidad, y propagación del contexto de workspace en proyectos, snapshots, dashboard y mock server.

Closes #89

Made with [Cursor](https://cursor.com)