### PR TITLE
feat(web): cuenta Clerk, workspace members y select menu

### DIFF
--- a/apps/web/src/app/features/account/account-section-page.component.css
+++ b/apps/web/src/app/features/account/account-section-page.component.css
@@ -55,19 +55,40 @@
   min-width: 0;
 }
 
-.account-section-page__avatar {
-  width: 40px;
-  height: 40px;
+.account-section-page__avatar-shell {
+  flex-shrink: 0;
+  width: 60px;
+  height: 60px;
   border-radius: 8px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  overflow: hidden;
+  line-height: 0;
   border: 1px solid var(--cp-border-muted);
+  box-sizing: border-box;
+}
+
+.account-section-page__avatar {
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  border-radius: 7px;
+  border: none;
   background: var(--cp-surface-app);
   color: var(--cp-text-icon-muted);
   font-size: 0.82rem;
   font-weight: 600;
   letter-spacing: 0.03em;
+}
+
+.account-section-page__avatar:not(.account-section-page__avatar--image) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.account-section-page__avatar--image {
+  display: block;
+  padding: 0;
+  object-fit: cover;
 }
 
 .account-section-page__profile-meta {
@@ -306,10 +327,10 @@
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  border: 1px solid transparent;
+  border: 1px solid var(--cp-border-default);
   border-radius: 8px;
-  background: var(--cp-accent-primary);
-  color: var(--cp-accent-on-primary);
+  background: var(--cp-surface-app);
+  color: var(--cp-text-primary);
   font: inherit;
   font-size: 0.8125rem;
   font-weight: 600;
@@ -319,7 +340,8 @@
 }
 
 .account-section-page__edit-btn:hover {
-  background: var(--cp-accent-primary-hover);
+  background: var(--cp-surface-subtle);
+  border-color: var(--cp-border-input-hover);
 }
 
 @media (max-width: 720px) {

--- a/apps/web/src/app/features/account/account-section-page.component.html
+++ b/apps/web/src/app/features/account/account-section-page.component.html
@@ -7,13 +7,25 @@
   @if (section() === 'account-profile-settings') {
     <section class="account-section-page__panel account-section-page__panel--profile" aria-label="Profile summary">
       <div class="account-section-page__profile-main">
-        <div class="account-section-page__avatar" aria-hidden="true">
-          <span>AC</span>
+        <div class="account-section-page__avatar-shell">
+          @if (profileDisplay().avatarUrl; as avatarSrc) {
+            <img
+              class="account-section-page__avatar account-section-page__avatar--image"
+              [src]="avatarSrc"
+              [alt]="'Avatar of ' + profileDisplay().fullName"
+            />
+          } @else {
+            <div class="account-section-page__avatar" aria-hidden="true">
+              <span>{{ profileDisplay().initials }}</span>
+            </div>
+          }
         </div>
         <div class="account-section-page__profile-meta">
-          <p class="account-section-page__name">{{ profile.fullName }}</p>
-          <p class="account-section-page__email">{{ profile.email }}</p>
-          <p class="account-section-page__company">{{ profile.company }}</p>
+          <p class="account-section-page__name">{{ profileDisplay().fullName }}</p>
+          <p class="account-section-page__email">{{ profileDisplay().email }}</p>
+          @if (profileDisplay().handle; as handle) {
+            <p class="account-section-page__company">{{ handle }}</p>
+          }
         </div>
       </div>
       <button type="button" class="account-section-page__edit-btn">
@@ -25,7 +37,7 @@
     <section class="account-section-page__panel" aria-label="Profile account information">
       <h2 class="account-section-page__section-title">Account Information</h2>
       <div class="account-section-page__info-list">
-        @for (field of accountFields; track field.label) {
+        @for (field of accountInfoFields(); track field.label) {
           <article class="account-section-page__info-row">
             <span class="account-section-page__info-icon" aria-hidden="true">
               @if (field.icon === 'copy') {
@@ -109,16 +121,6 @@
 
   @if (section() === 'account-plan-billing') {
     <section class="account-section-page__panel" aria-label="Plan and billing section">
-      <div class="account-section-page__panel-head account-section-page__panel-head--actions-only">
-        <button
-          type="button"
-          class="account-section-page__icon-btn"
-          title="Copy billing summary"
-          aria-label="Copy billing summary"
-        >
-          <svg lucideCopy [size]="16" strokeWidth="1.75" aria-hidden="true"></svg>
-        </button>
-      </div>
       <article class="account-section-page__billing-card">
         <p class="account-section-page__billing-plan">
           Current Plan:

--- a/apps/web/src/app/features/account/account-section-page.component.ts
+++ b/apps/web/src/app/features/account/account-section-page.component.ts
@@ -1,5 +1,7 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { LucideCopy, LucideFileText, LucideHistory, LucidePencilLine, LucideUsers } from '@lucide/angular';
+
+import { FrontendAuthSessionService } from '../../shared/auth/frontend-auth-session.service';
 
 type AccountSectionNavId =
   | 'account-profile-settings'
@@ -24,20 +26,46 @@ interface AccountField {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AccountSectionPageComponent {
+  private readonly authSession = inject(FrontendAuthSessionService);
+
   readonly section = input.required<AccountSectionNavId>();
 
-  protected readonly profile = {
-    fullName: 'Alex Chen',
-    email: 'alex.chen@company.com',
-    company: 'TechCorp Inc',
-  };
+  /** Mock: sustituir por dato real cuando exista API de billing (`Free` | `Pro`). */
+  protected readonly accountPlanMock: 'Free' | 'Pro' = 'Free';
 
-  protected readonly accountFields: readonly AccountField[] = [
-    { icon: 'copy', label: 'Email', value: 'alex.chen@company.com' },
-    { icon: 'users', label: 'Role', value: 'Admin' },
-    { icon: 'history', label: 'Joined', value: 'January 14, 2023' },
-    { icon: 'file', label: 'Last login', value: 'Apr 25, 2026 at 07:38 PM' },
-  ];
+  /** Perfil desde la sesión Clerk (misma fuente que el sidebar y las llamadas API). */
+  protected readonly profileDisplay = computed(() => {
+    const s = this.authSession.snapshot();
+    const email = s.email?.trim() || null;
+    const displayName = s.displayName?.trim() || null;
+    const primaryLabel = displayName || email;
+    const rawUser = s.username?.trim();
+    const handle = rawUser != null && rawUser.length > 0 ? (rawUser.startsWith('@') ? rawUser : `@${rawUser}`) : null;
+    const avatarUrl = s.avatarUrl?.trim() || null;
+
+    return {
+      fullName: primaryLabel ?? '—',
+      email: email ?? '—',
+      handle,
+      avatarUrl,
+      initials: initialsFromName(primaryLabel ?? email ?? '?'),
+    };
+  });
+
+  protected readonly accountInfoFields = computed((): AccountField[] => {
+    const s = this.authSession.snapshot();
+    const email = s.email?.trim() || '—';
+    const raw = s.username?.trim();
+    const username = raw != null && raw.length > 0 ? (raw.startsWith('@') ? raw : `@${raw}`) : '—';
+    const verified = s.emailVerified ? 'Yes' : 'No';
+
+    return [
+      { icon: 'copy', label: 'Email', value: email },
+      { icon: 'users', label: 'Username', value: username },
+      { icon: 'history', label: 'Email verified', value: verified },
+      { icon: 'file', label: 'Account plan', value: this.accountPlanMock },
+    ];
+  });
 
   protected readonly billingHighlights: readonly string[] = ['5 endpoints', '1000 requests/month', 'No AI generation'];
 
@@ -63,4 +91,16 @@ export class AccountSectionPageComponent {
         return 'Plan / Billing';
     }
   });
+}
+
+function initialsFromName(displayName: string): string {
+  const words = displayName.split(/\s+/).filter(Boolean);
+  if (words.length === 1) {
+    const w = words[0] ?? '';
+    return w.slice(0, 2).toUpperCase();
+  }
+  return words
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? '')
+    .join('');
 }

--- a/apps/web/src/app/features/workspace-members/workspace-members-page.component.css
+++ b/apps/web/src/app/features/workspace-members/workspace-members-page.component.css
@@ -219,6 +219,20 @@
   cursor: not-allowed;
 }
 
+.workspace-members-page__remove--icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  color: var(--cp-text-icon-muted);
+}
+
+.workspace-members-page__remove--icon:hover:not(:disabled) {
+  color: var(--cp-text-primary);
+}
+
 .workspace-members-page__form {
   display: flex;
   flex-direction: row;
@@ -269,7 +283,17 @@
 
 .workspace-members-page__role-menu::ng-deep .select-menu__trigger {
   min-height: 2.25rem;
+}
+
+/* Ancho amplio solo cuando el trigger muestra texto; si no, gana el compacto del select-menu. */
+.workspace-members-page__role-menu::ng-deep .select-menu:not(.select-menu--trigger-icon-only) .select-menu__trigger {
   min-width: 8.5rem;
+}
+
+.workspace-members-page__role-menu::ng-deep .select-menu--trigger-icon-only .select-menu__trigger {
+  min-width: 2.85rem;
+  width: auto;
+  max-width: none;
 }
 
 .workspace-members-page__submit {

--- a/apps/web/src/app/features/workspace-members/workspace-members-page.component.html
+++ b/apps/web/src/app/features/workspace-members/workspace-members-page.component.html
@@ -51,6 +51,7 @@
                   [options]="memberRoleOptions"
                   [value]="member.role"
                   [disabled]="!canEditMemberRole(member)"
+                  [iconOnlyTrigger]="true"
                   (valueChange)="onMemberRoleChange(member, $event)"
                   [triggerId]="'workspace-member-role-trigger-' + member.userId"
                   [listboxId]="'workspace-member-role-listbox-' + member.userId"
@@ -59,11 +60,13 @@
               @if (canManageMembers() && canRemoveMember(member)) {
                 <button
                   type="button"
-                  class="workspace-members-page__remove"
+                  class="workspace-members-page__remove workspace-members-page__remove--icon"
+                  title="Remove member"
+                  aria-label="Remove member"
                   [disabled]="mutationPending()"
                   (click)="onRemoveMember(member.userId)"
                 >
-                  Remove
+                  <svg lucideTrash2 [size]="16" strokeWidth="1.75" aria-hidden="true"></svg>
                 </button>
               }
             </li>
@@ -82,6 +85,15 @@
           "
         >
           <div class="workspace-members-page__form-fields">
+            <app-select-menu
+              class="workspace-members-page__role-menu"
+              [options]="inviteRoleOptions"
+              [value]="selectedRole()"
+              [iconOnlyTrigger]="true"
+              (valueChange)="onRoleChange($event)"
+              [triggerId]="'workspace-members-role-trigger'"
+              [listboxId]="'workspace-members-role-listbox'"
+            />
             <input
               #memberEmail
               type="email"
@@ -89,14 +101,6 @@
               required
               placeholder="colleague@example.com"
               class="workspace-members-page__input"
-            />
-            <app-select-menu
-              class="workspace-members-page__role-menu"
-              [options]="inviteRoleOptions"
-              [value]="selectedRole()"
-              (valueChange)="onRoleChange($event)"
-              [triggerId]="'workspace-members-role-trigger'"
-              [listboxId]="'workspace-members-role-listbox'"
             />
           </div>
           <button

--- a/apps/web/src/app/features/workspace-members/workspace-members-page.component.spec.ts
+++ b/apps/web/src/app/features/workspace-members/workspace-members-page.component.spec.ts
@@ -123,7 +123,7 @@ describe('WorkspaceMembersPageComponent', () => {
     expect(rows[0]?.querySelector('.workspace-members-page__remove')).toBeNull();
     expect(rows[0]?.querySelector('.workspace-members-page__badge--owner')?.textContent).toContain('Owner');
     expect(rows[0]?.querySelector('.workspace-members-page__badge--self')?.textContent).toContain('You');
-    expect(rows[1]?.querySelector('.workspace-members-page__remove')?.textContent).toContain('Remove');
+    expect(rows[1]?.querySelector('.workspace-members-page__remove')?.getAttribute('aria-label')).toBe('Remove member');
   });
 
   it('shows remove button for owner self in non-personal workspaces when no other restriction applies', async () => {
@@ -137,7 +137,7 @@ describe('WorkspaceMembersPageComponent', () => {
     expect(rows[0]?.textContent).toContain('Owner User');
     expect(rows[0]?.querySelector('.workspace-members-page__badge--owner')?.textContent).toContain('Owner');
     expect(rows[0]?.querySelector('.workspace-members-page__badge--self')?.textContent).toContain('You');
-    expect(rows[0]?.querySelector('.workspace-members-page__remove')?.textContent).toContain('Remove');
+    expect(rows[0]?.querySelector('.workspace-members-page__remove')?.getAttribute('aria-label')).toBe('Remove member');
   });
 
   it('detects current user by email when userId differs in personal workspaces', async () => {
@@ -222,7 +222,7 @@ describe('WorkspaceMembersPageComponent', () => {
     form.dispatchEvent(new Event('submit'));
 
     expect(emitSpy).toHaveBeenCalledWith({ email: 'newcomer@example.com', role: 'editor' });
-    expect(roleTrigger.textContent).toContain('Editor');
+    expect(roleTrigger.getAttribute('aria-label')).toContain('Editor');
     expect(element.querySelector('.workspace-members-page__submit')?.textContent).toContain('Send invite');
   });
 

--- a/apps/web/src/app/features/workspace-members/workspace-members-page.component.ts
+++ b/apps/web/src/app/features/workspace-members/workspace-members-page.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { LucideUsers } from '@lucide/angular';
+import { LucideTrash2, LucideUsers } from '@lucide/angular';
 import { SelectMenuComponent, type SelectMenuOption } from '../../shared/ui/select-menu/select-menu.component';
 
 import type { InvitableWorkspaceRoleDto, WorkspaceInvitationDto, WorkspaceRoleDto } from '../../shared/http/api.types';
@@ -20,7 +20,7 @@ export interface WorkspacePageWorkspaceSummary {
 @Component({
   selector: 'app-workspace-members-page',
   standalone: true,
-  imports: [FormsModule, LucideUsers, SelectMenuComponent],
+  imports: [FormsModule, LucideTrash2, LucideUsers, SelectMenuComponent],
   templateUrl: './workspace-members-page.component.html',
   styleUrls: ['./workspace-members-page.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -43,13 +43,13 @@ export class WorkspaceMembersPageComponent {
   readonly removeMember = output<string>();
 
   protected readonly memberRoleOptions: readonly SelectMenuOption[] = [
-    { value: 'viewer', label: 'Viewer' },
-    { value: 'editor', label: 'Editor' },
-    { value: 'owner', label: 'Owner' },
+    { value: 'viewer', label: 'Viewer', icon: 'eye' },
+    { value: 'editor', label: 'Editor', icon: 'pencil' },
+    { value: 'owner', label: 'Owner', icon: 'crown' },
   ];
   protected readonly inviteRoleOptions: readonly SelectMenuOption[] = [
-    { value: 'viewer', label: 'Viewer' },
-    { value: 'editor', label: 'Editor' },
+    { value: 'viewer', label: 'Viewer', icon: 'eye' },
+    { value: 'editor', label: 'Editor', icon: 'pencil' },
   ];
   protected readonly selectedRole = signal<InvitableWorkspaceRoleDto>(
     WorkspaceMembersPageComponent.DEFAULT_INVITE_ROLE,
@@ -102,7 +102,7 @@ export class WorkspaceMembersPageComponent {
   }
 
   protected canEditMemberRole(member: WorkspaceMember): boolean {
-    if (!this.canManageMembers() || this.mutationPending()) {
+    if (!this.canManageMembers()) {
       return false;
     }
 

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.spec.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.spec.ts
@@ -697,16 +697,32 @@ describe('WorkspaceShellComponent', () => {
     expect(workspaceInvitationsRepository.listPendingInvitations).toHaveBeenCalledTimes(2);
   });
 
-  it('refreshes project summary and workspace members after updating a member role', async () => {
+  it('updates workspace members from PATCH response after updating a member role', async () => {
     projectsRepository.listProjects.mockResolvedValue(pagedProjectsResult([projectFixture]));
     projectsRepository.getProject.mockResolvedValue(projectFixture);
-    workspaceMembersRepository.listMembers.mockResolvedValue([] as WorkspaceMember[]);
+    const initialMembers: WorkspaceMember[] = [
+      {
+        userId: 'user-1',
+        email: 'owner@example.com',
+        displayName: 'Owner User',
+        role: 'owner',
+        createdAt: '2026-04-08T10:00:00.000Z',
+      },
+      {
+        userId: 'user-2',
+        email: 'editor@example.com',
+        displayName: 'Editor User',
+        role: 'editor',
+        createdAt: '2026-04-08T10:05:00.000Z',
+      },
+    ];
+    workspaceMembersRepository.listMembers.mockResolvedValue(initialMembers);
     workspaceMembersRepository.updateMemberRole.mockResolvedValue({
       userId: 'user-2',
       email: 'editor@example.com',
       displayName: 'Editor User',
       role: 'owner',
-      createdAt: '2026-04-08T10:00:00.000Z',
+      createdAt: '2026-04-08T10:05:00.000Z',
     });
 
     const component = createComponent();
@@ -717,8 +733,12 @@ describe('WorkspaceShellComponent', () => {
     component.updateWorkspaceMemberRole({ memberUserId: 'user-2', role: 'owner' });
     await flushAsyncWork();
 
-    expect(projectsRepository.getProject).toHaveBeenCalledWith('project-1');
-    expect(workspaceMembersRepository.listMembers).toHaveBeenCalledWith('workspace-1');
+    expect(workspaceMembersRepository.updateMemberRole).toHaveBeenCalledWith('workspace-1', 'user-2', {
+      role: 'owner',
+    });
+    expect(projectsRepository.getProject).not.toHaveBeenCalled();
+    expect(workspaceMembersRepository.listMembers).not.toHaveBeenCalled();
+    expect(component.workspaceMembers().find((m) => m.userId === 'user-2')?.role).toBe('owner');
   });
 
   it('reloads workspace members and exposes a workspace summary when the user navigates to the workspace section', async () => {

--- a/apps/web/src/app/features/workspace-shell/workspace-shell.component.ts
+++ b/apps/web/src/app/features/workspace-shell/workspace-shell.component.ts
@@ -745,7 +745,7 @@ export class WorkspaceShellComponent implements OnInit {
       return;
     }
 
-    void this.updateWorkspaceMemberRoleRemote(activeProject.id, workspaceId, input);
+    void this.updateWorkspaceMemberRoleRemote(workspaceId, input);
   }
 
   protected removeWorkspaceMember(memberUserId: string): void {
@@ -893,7 +893,7 @@ export class WorkspaceShellComponent implements OnInit {
     try {
       const refreshed = await this.projectsRepository.getProject(projectId);
       this.projects.update((projects) => projects.map((project) => (project.id === projectId ? refreshed : project)));
-      await this.reloadWorkspaceMembers(refreshed.workspace.id);
+      await this.reloadWorkspaceMembers(refreshed.workspace.id, { silent: true });
       await this.reloadPendingWorkspaceInvitations();
       if (this.activeNav() === 'history') {
         await this.loadSnapshotHistory(projectId, true);
@@ -1288,8 +1288,11 @@ export class WorkspaceShellComponent implements OnInit {
     }
   }
 
-  private async reloadWorkspaceMembers(workspaceId: string): Promise<void> {
-    this.workspaceMembersLoading.set(true);
+  private async reloadWorkspaceMembers(workspaceId: string, options?: { silent?: boolean }): Promise<void> {
+    const silent = options?.silent ?? false;
+    if (!silent) {
+      this.workspaceMembersLoading.set(true);
+    }
     this.workspaceMembersError.set(null);
 
     try {
@@ -1301,7 +1304,9 @@ export class WorkspaceShellComponent implements OnInit {
       this.workspaceInvitations.set([]);
       this.workspaceMembersError.set(error instanceof Error ? error.message : 'Could not load workspace members.');
     } finally {
-      this.workspaceMembersLoading.set(false);
+      if (!silent) {
+        this.workspaceMembersLoading.set(false);
+      }
     }
   }
 
@@ -1384,7 +1389,6 @@ export class WorkspaceShellComponent implements OnInit {
   }
 
   private async updateWorkspaceMemberRoleRemote(
-    projectId: string,
     workspaceId: string,
     input: { memberUserId: string; role: 'owner' | 'editor' | 'viewer' },
   ): Promise<void> {
@@ -1392,8 +1396,12 @@ export class WorkspaceShellComponent implements OnInit {
     this.workspaceMembersError.set(null);
 
     try {
-      await this.workspaceMembersRepository.updateMemberRole(workspaceId, input.memberUserId, { role: input.role });
-      await this.reloadProjects(projectId);
+      const updated = await this.workspaceMembersRepository.updateMemberRole(workspaceId, input.memberUserId, {
+        role: input.role,
+      });
+      this.workspaceMembers.update((members) =>
+        members.map((member) => (member.userId === updated.userId ? updated : member)),
+      );
     } catch (error) {
       this.workspaceMembersError.set(
         error instanceof Error ? error.message : 'Could not update workspace member role.',

--- a/apps/web/src/app/shared/ui/select-menu/select-menu.component.css
+++ b/apps/web/src/app/shared/ui/select-menu/select-menu.component.css
@@ -38,6 +38,13 @@
   box-shadow: 0 0 0 1px var(--cp-accent-focus-ring);
 }
 
+.select-menu__trigger--icon-only {
+  min-width: 2.85rem;
+  justify-content: center;
+  padding-left: 0.45rem;
+  padding-right: 2rem;
+}
+
 .select-menu__icon {
   display: flex;
   flex-shrink: 0;
@@ -76,8 +83,11 @@
   z-index: 100;
   top: calc(100% + 6px);
   left: 0;
-  right: 0;
+  right: auto;
   box-sizing: border-box;
+  min-width: 100%;
+  width: max-content;
+  max-width: min(22rem, calc(100vw - 2rem));
   padding: 0.3rem;
   border: 1px solid var(--cp-menu-border);
   border-radius: 10px;
@@ -86,7 +96,7 @@
 }
 
 .select-menu__option {
-  display: block;
+  display: flex;
   width: 100%;
   padding: 0.5rem 0.65rem;
   border: none;
@@ -98,6 +108,28 @@
   font-size: 0.8125rem;
   line-height: 1.25;
   cursor: pointer;
+  align-items: center;
+}
+
+.select-menu__option-inner {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  min-width: 0;
+}
+
+.select-menu__option-icon {
+  display: flex;
+  flex-shrink: 0;
+  color: var(--cp-text-icon-muted);
+}
+
+.select-menu__option--current .select-menu__option-icon {
+  color: inherit;
+}
+
+.select-menu__option-label {
+  min-width: 0;
 }
 
 .select-menu__option:hover,

--- a/apps/web/src/app/shared/ui/select-menu/select-menu.component.html
+++ b/apps/web/src/app/shared/ui/select-menu/select-menu.component.html
@@ -1,18 +1,31 @@
-<div class="select-menu">
+<div class="select-menu" [class.select-menu--trigger-icon-only]="triggerHidesLabel">
   <button
     type="button"
     class="select-menu__trigger"
+    [class.select-menu__trigger--icon-only]="triggerHidesLabel"
     [id]="triggerId"
     [disabled]="disabled"
     [attr.aria-expanded]="open()"
     aria-haspopup="listbox"
     [attr.aria-controls]="listboxId"
+    [attr.aria-label]="triggerAccessibleName"
+    [attr.title]="triggerHidesLabel ? currentLabel : null"
     (click)="toggle()"
   >
     <span class="select-menu__icon">
-      <ng-content select="[data-select-menu-icon]"></ng-content>
+      @if (currentIcon === 'eye') {
+        <svg lucideEye [size]="14" strokeWidth="2" aria-hidden="true"></svg>
+      } @else if (currentIcon === 'pencil') {
+        <svg lucidePencil [size]="14" strokeWidth="2" aria-hidden="true"></svg>
+      } @else if (currentIcon === 'crown') {
+        <svg lucideCrown [size]="14" strokeWidth="2" aria-hidden="true"></svg>
+      } @else {
+        <ng-content select="[data-select-menu-icon]"></ng-content>
+      }
     </span>
-    <span class="select-menu__label">{{ currentLabel }}</span>
+    @if (!triggerHidesLabel) {
+      <span class="select-menu__label">{{ currentLabel }}</span>
+    }
     <span class="select-menu__chevron" [class.select-menu__chevron--open]="open()" aria-hidden="true">
       <svg
         width="14"
@@ -39,7 +52,22 @@
           [attr.aria-selected]="value === opt.value"
           (click)="pick(opt.value)"
         >
-          {{ opt.label }}
+          <span class="select-menu__option-inner">
+            @if (opt.icon === 'eye') {
+              <span class="select-menu__option-icon" aria-hidden="true">
+                <svg lucideEye [size]="14" strokeWidth="2"></svg>
+              </span>
+            } @else if (opt.icon === 'pencil') {
+              <span class="select-menu__option-icon" aria-hidden="true">
+                <svg lucidePencil [size]="14" strokeWidth="2"></svg>
+              </span>
+            } @else if (opt.icon === 'crown') {
+              <span class="select-menu__option-icon" aria-hidden="true">
+                <svg lucideCrown [size]="14" strokeWidth="2"></svg>
+              </span>
+            }
+            <span class="select-menu__option-label">{{ opt.label }}</span>
+          </span>
         </button>
       }
     </div>

--- a/apps/web/src/app/shared/ui/select-menu/select-menu.component.ts
+++ b/apps/web/src/app/shared/ui/select-menu/select-menu.component.ts
@@ -9,15 +9,21 @@ import {
   Output,
   signal,
 } from '@angular/core';
+import { LucideCrown, LucideEye, LucidePencil } from '@lucide/angular';
+
+/** Iconos admitidos en opciones con pictograma (p. ej. roles de workspace). */
+export type SelectMenuIconKey = 'eye' | 'pencil' | 'crown';
 
 export interface SelectMenuOption {
   readonly value: string;
   readonly label: string;
+  readonly icon?: SelectMenuIconKey;
 }
 
 @Component({
   selector: 'app-select-menu',
   standalone: true,
+  imports: [LucideCrown, LucideEye, LucidePencil],
   templateUrl: './select-menu.component.html',
   styleUrls: ['./select-menu.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -31,11 +37,25 @@ export class SelectMenuComponent {
   @Output() readonly valueChange = new EventEmitter<string>();
   @Input({ required: true }) triggerId = '';
   @Input({ required: true }) listboxId = '';
+  /** Si es true y la opción activa tiene `icon`, el trigger muestra solo icono + chevron (p. ej. roles). */
+  @Input() iconOnlyTrigger = false;
 
   protected readonly open = signal(false);
 
   protected get currentLabel(): string {
     return this.options.find((option) => option.value === this.value)?.label ?? '';
+  }
+
+  protected get currentIcon(): SelectMenuIconKey | undefined {
+    return this.options.find((option) => option.value === this.value)?.icon;
+  }
+
+  protected get triggerHidesLabel(): boolean {
+    return this.iconOnlyTrigger && this.currentIcon !== undefined;
+  }
+
+  protected get triggerAccessibleName(): string | null {
+    return this.triggerHidesLabel ? this.currentLabel.trim() || 'Option' : null;
   }
 
   protected toggle(): void {

--- a/apps/web/src/build-budget-fixes.css
+++ b/apps/web/src/build-budget-fixes.css
@@ -1183,8 +1183,12 @@ app-global-config-drawer,
 }
 
 .gcfg-dual-range {
+  --gcfg-dual-track-h: 0.35rem;
+  --gcfg-dual-thumb: 1rem;
+  --gcfg-dual-slot-h: 1.5rem;
+
   position: relative;
-  height: 1.35rem;
+  height: var(--gcfg-dual-slot-h);
   margin-top: 0.15rem;
 }
 
@@ -1193,8 +1197,8 @@ app-global-config-drawer,
   left: 0;
   right: 0;
   top: 50%;
-  height: 0.35rem;
-  margin-top: -0.175rem;
+  height: var(--gcfg-dual-track-h);
+  margin-top: calc(var(--gcfg-dual-track-h) / -2);
   border-radius: 999px;
   pointer-events: none;
 }
@@ -1203,29 +1207,35 @@ app-global-config-drawer,
   position: absolute;
   left: 0;
   width: 100%;
-  height: 1.35rem;
+  height: var(--gcfg-dual-slot-h);
   margin: 0;
+  padding: 0;
   background: none;
   pointer-events: none;
   appearance: none;
   top: 0;
+  box-sizing: border-box;
 }
 
 .gcfg-dual-range__input::-webkit-slider-thumb {
   appearance: none;
-  width: 1rem;
-  height: 1rem;
+  box-sizing: border-box;
+  width: var(--gcfg-dual-thumb);
+  height: var(--gcfg-dual-thumb);
   border-radius: 50%;
   background: #f4f4f5;
   border: 2px solid rgba(15, 23, 42, 0.9);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
   cursor: grab;
   pointer-events: auto;
+  /* Centrar el thumb sobre la pista (Chrome/Safari/Edge). */
+  margin-top: calc((var(--gcfg-dual-track-h) - var(--gcfg-dual-thumb)) / 2);
 }
 
 .gcfg-dual-range__input::-moz-range-thumb {
-  width: 1rem;
-  height: 1rem;
+  box-sizing: border-box;
+  width: var(--gcfg-dual-thumb);
+  height: var(--gcfg-dual-thumb);
   border-radius: 50%;
   background: #f4f4f5;
   border: 2px solid rgba(15, 23, 42, 0.9);
@@ -1235,13 +1245,16 @@ app-global-config-drawer,
 }
 
 .gcfg-dual-range__input::-webkit-slider-runnable-track {
-  height: 0.35rem;
+  height: var(--gcfg-dual-track-h);
   background: transparent;
   border-radius: 999px;
+  /* La pista por defecto queda arriba del área del input; centrarla en el slot. */
+  margin-top: calc((var(--gcfg-dual-slot-h) - var(--gcfg-dual-track-h)) / 2);
+  margin-bottom: calc((var(--gcfg-dual-slot-h) - var(--gcfg-dual-track-h)) / 2);
 }
 
 .gcfg-dual-range__input::-moz-range-track {
-  height: 0.35rem;
+  height: var(--gcfg-dual-track-h);
   background: transparent;
   border-radius: 999px;
 }


### PR DESCRIPTION
## Resumen
Mejoras de UI y datos en cuenta, miembros de workspace, select compartido y ajustes de shell/config.

## Cambios
- **Cuenta**: perfil e información desde sesión Clerk; avatar 60px; botón Edit con estilo secundario; fila **Account plan** (mock Free/Pro); eliminada cabecera vacía en Plan/Billing.
- **Workspace members**: quitar miembro con icono + tooltip; menú de rol a la izquierda del email; iconos en opciones de rol; trigger solo icono; corrección de anchos (panel vs trigger).
- **Select menu**: iconos opcionales en opciones; panel desplegable con `min-width: 100%` y `width: max-content`.
- **Global config**: centrado vertical del dual-range (WebKit) en `build-budget-fixes.css`.
- **Workspace shell**: al cambiar rol de miembro se aplica la respuesta del PATCH sin `refreshProject`; menos parpadeo; reload silencioso de miembros en `refreshProject`.

## Tests
- Vitest: workspace-shell y workspace-members (ejecutados en local durante el desarrollo).

Made with [Cursor](https://cursor.com)

Closes #90
